### PR TITLE
py for windows and custom head

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -14,11 +14,11 @@ Minification
 - Here we check there is python3, and pip3, and then if we fail to import, we try to
 use pip3 to install it.
 =#
-const JD_HAS_PY3    = try success(`python3 -V`); catch; false; end
+const JD_HAS_PY3    = try success(`py -3 -V`) ||
+                        success(`python3 -V`); catch; false; end
 const JD_HAS_PIP3   = try success(`pip3 -V`); catch; false; end
 const JD_CAN_MINIFY = JD_HAS_PY3 && JD_HAS_PIP3 &&
-                      try success(`python3 -m "import css_html_js_minify"`) ||
-                          success(`pip3 install css_html_js_minify`); catch; false; end
+                      try success(`python3 -m "import css_html_js_minify"`) ||  success(`pip3 install css_html_js_minify`);catch; try success(`py -3 -m "import css_html_js_minify"`) ||  success(`pip3 install css_html_js_minify`);catch; false ;end; end
 
 #=
 Information to the user

--- a/src/manager/judoc.jl
+++ b/src/manager/judoc.jl
@@ -5,6 +5,7 @@ Runs JuDoc in the current directory.
 
 Keyword arguments:
 
+* `head = "head.html"`:     allows you to use a custom head.html. Useful for github pages for projects. 
 * `clear=false`:     whether to remove any existing output directory
 * `verb=false`:      whether to display messages
 * `port=8000`:       the port to use for the local server (should pick a number between 8000 and 9000)
@@ -12,17 +13,17 @@ Keyword arguments:
 * `prerender=false`: whether to pre-render javascript (KaTeX and highlight.js)
 * `nomess=false`:    suppresses all messages (internal use).
 """
-function serve(; clear::Bool=true, verb::Bool=false, port::Int=8000, single::Bool=false,
+function serve(;head::String="head.html", clear::Bool=true, verb::Bool=false, port::Int=8000, single::Bool=false,
                  prerender::Bool=false, nomess::Bool=false)::Union{Nothing,Int}
     # set the global path
     JD_FOLDER_PATH[] = pwd()
 
     # brief check to see if we're in a folder that looks promising, otherwise stop
-    # and tell the user to check (#155)
-    if !isdir(joinpath(JD_FOLDER_PATH[], "src"))
-        throw(ArgumentError("The current directory doesn't have a src/ folder. " *
-                            "Please change directory to a valid JuDoc folder."))
-    end
+       # and tell the user to check (#155)
+       if !isdir(joinpath(JD_FOLDER_PATH[], "src"))
+           throw(ArgumentError("The current directory doesn't have a src/ folder. " *
+                               "Please change directory to a valid JuDoc folder."))
+       end
 
 
     # construct the set of files to watch
@@ -33,7 +34,7 @@ function serve(; clear::Bool=true, verb::Bool=false, port::Int=8000, single::Boo
     # do a first full pass
     nomess || println("→ Initial full pass... ")
     start = time()
-    sig = jd_fullpass(watched_files; clear=clear, verb=verb, prerender=prerender)
+    sig = jd_fullpass(head,watched_files; clear=clear, verb=verb, prerender=prerender)
     sig < 0 && return sig
     verb && (print(rpad("\n✔ full pass...", 40)); time_it_took(start); println(""))
 
@@ -96,10 +97,10 @@ A single full pass of judoc looking at all watched files and processing them as 
 
 See also [`jd_loop`](@ref), [`serve`](@ref) and [`publish`](@ref).
 """
-function jd_fullpass(watched_files::NamedTuple; clear::Bool=false, verb::Bool=false,
+function jd_fullpass(head,watched_files::NamedTuple; clear::Bool=false, verb::Bool=false,
                      prerender::Bool=false)::Int
      # initiate page segments
-     head    = read(joinpath(JD_PATHS[:in_html], "head.html"), String)
+     head    = read(joinpath(JD_PATHS[:in_html], head), String)
      pg_foot = read(joinpath(JD_PATHS[:in_html], "page_foot.html"), String)
      foot    = read(joinpath(JD_PATHS[:in_html], "foot.html"), String)
 


### PR DESCRIPTION
Hi guys,

I am not sure if this is the right way to do it, so my apologies if I am wrong.

I made 2 modifications in the package that may be interesting:

1. On windows, I can only run python via `py -3`, so every time I built the package it said that python was not installed. I simply added a try for `py -3` on build.jl. It works here, and might solve this for some windows users (although this is not something that prevents people using the package, it might be handy and was really simple). I kept the `python3` because I guess this is how unix/osx calls python3. I think it might work in those systems, but I haven't tried it.

2. Another change is on the `serve()` command: I added an option for a custom _head.html_. To understand why this is useful, it is not straight forward to generate a webpage for a repo - only for the user. I am using this package to write a [small guide for economists](https://danmrc.github.io/Julia-Para-Economistas/) using Julia (in portuguese, which is my native language and is far from complete). It took me a couple of hours to understand exactly what I had to change in order to this work, but I did. 

To make it work, the biggest problem was with _head.html_ so it would get the files from the right address. [Here is the modified head](https://github.com/danmrc/Julia-Para-Economistas/blob/master/Julia%20Para%20Economistas/src/_html_parts/head.html). However, this generated another problem: I could not serve it and take a look at the site, since the _head.html_ was written to point to the right paths in github.

My solution was to create two head files, one for serving and one for publishing. Since I am publishing inside a docs folder in github, I don't use `publish()` . Therefore, I changed `serve()`. I have tested it and it works, but I have not tested in another OS.

I hope this can be useful for the package

Best regards