### PR TITLE
closes #162 allows a pre-path to be specified in the optimisation/pub…

### DIFF
--- a/src/converter/html.jl
+++ b/src/converter/html.jl
@@ -3,7 +3,8 @@ $(SIGNATURES)
 
 Convert a judoc html string into a html string (i.e. replace `{{ ... }}` blocks).
 """
-function convert_html(hs::AbstractString, allvars::JD_VAR_TYPE, fpath::AbstractString="")::String
+function convert_html(hs::AbstractString, allvars::JD_VAR_TYPE, fpath::AbstractString="";
+                      isoptim::Bool=false)::String
     # Tokenize
     tokens = find_tokens(hs, HTML_TOKENS, HTML_1C_TOKENS)
 
@@ -41,5 +42,10 @@ function convert_html(hs::AbstractString, allvars::JD_VAR_TYPE, fpath::AbstractS
     δ = ifelse(endswith(fhs, "</p>\n") && !startswith(fhs, "<p>"), 5, 0)
 
     isempty(fhs) && return ""
+
+    if !isempty(JD_GLOB_VARS["prepath"]) && isoptim
+        fhs = fix_links(fhs)
+    end
+
     return String(chop(fhs, tail=δ))
 end

--- a/src/jd_vars.jl
+++ b/src/jd_vars.jl
@@ -23,6 +23,7 @@ when JuDoc is started.
     JD_GLOB_VARS["date_format"] = Pair("U dd, yyyy",   (String,))
     JD_GLOB_VARS["baseurl"]     = Pair(nothing,        (String, Nothing))
     JD_GLOB_VARS["codetheme"]   = Pair(Themes.DefaultTheme, (Highlights.AbstractTheme, Nothing))
+    JD_GLOB_VARS["prepath"]     = Pair("",             (String,))
     return nothing
 end
 


### PR DESCRIPTION
Following calls are allowed:

* `optimize(...; prepath="testproj")`
* `publish(...;prepath="testproj")`
* in config.md `@def prepath = "testproj"`

All this will result in the same thing (provided `optimize` and/or `publish` is used at some point): all paths `href="/..."` and `src="/..."` will be prepended with `/testproj/...`. For instance: https://tlienart.github.io/testproj/

This may not be the most elegant approach but it solves #162, we may revisit this in the future to do something that's more robust.

* edit: could do with tests and docs