### PR TITLE
Update highlight install command

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,7 @@ This step requires a few external dependencies:
 Assuming you have those, you will then need to install `highlight.js` via `npm`:
 
 ```bash
-[sudo] npm install -g highlight.js
+[sudo] npm install --save -g highlight.js
 ```
 
 and the python package [`css_html_js_minify`](https://github.com/juancarlospaco/css-html-js-minify) which you can install with `pip3` (if you have python3, JuDoc will try to do this for you):


### PR DESCRIPTION
I've experienced some issues with the `highlight.js` package installation, and finally this command solved it:
```bash
[sudo] npm install --save -g highlight.js
```
So `--save` is needed (in my case at least). I'm not experienced with node.js at all, so it's possible that it's not a perfect solution.
Sources:
[stackoverflow](https://stackoverflow.com/a/30886703), [meteor issue](https://github.com/meteor/meteor/issues/8119#issuecomment-264224373).

Edit: I think this caused #174 (at least the node.js part).