### PR TITLE
fix cleanpull()

### DIFF
--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -114,7 +114,7 @@ function cleanpull()::Nothing
         println(" [done ✔ ]")
     end
     try
-        print(rpad("→ Retrieving updates from the repository..."), 35)
+        print(rpad("→ Retrieving updates from the repository...", 35))
         run(`git pull --quiet`)
         println(" [done ✔ ]")
     catch e


### PR DESCRIPTION
In short:
old:
```
julia>  print(rpad("→ Retrieving updates from the repository..."), 35)
ERROR: MethodError: no method matching rpad(::String)
Closest candidates are:
  rpad(::Union{AbstractChar, AbstractString}, ::Integer) at strings/util.jl:269
  rpad(::Union{AbstractChar, AbstractString}, ::Integer, ::Union{AbstractChar, AbstractString}) at strings/util.jl:269
  rpad(::Any, ::Integer) at strings/util.jl:262
  ...
Stacktrace:
 [1] top-level scope at none:0
```
Fix:
```
julia>  print(rpad("→ Retrieving updates from the repository...", 35))
→ Retrieving updates from the repository...
```