### PR TITLE
Add error message in eval block (see #186)

### DIFF
--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -138,8 +138,8 @@ function convert_code_block(ss::SubString)::String
             redirect_stdout(outf)  do
                 try
                     Main.include(path)
-                catch
-                    print("There was an error running the code.")
+                catch e
+                    print("There was an error running the code: $e.")
                 end
             end
         end

--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -139,7 +139,7 @@ function convert_code_block(ss::SubString)::String
                 try
                     Main.include(path)
                 catch e
-                    print("There was an error running the code: $e.")
+                    print("There was an error running the code: $(e.error).")
                 end
             end
         end

--- a/test/converter/eval.jl
+++ b/test/converter/eval.jl
@@ -132,8 +132,7 @@ end
         done.
         """ * J.EOS |> seval
     # errors silently
-    @test occursin("then: <pre><code>There was an error running the code:", h)
-    @test occursin("DomainError", h)
+    @test occursin("then: <pre><code>There was an error running the code: DomainError", h)
 end
 
 @testset "Eval code (no-julia)" begin

--- a/test/converter/eval.jl
+++ b/test/converter/eval.jl
@@ -132,7 +132,8 @@ end
         done.
         """ * J.EOS |> seval
     # errors silently
-    @test occursin("then: <pre><code>There was an error running the code.</code></pre>", h)
+    @test occursin("then: <pre><code>There was an error running the code:", h)
+    @test occursin("DomainError", h)
 end
 
 @testset "Eval code (no-julia)" begin
@@ -145,4 +146,31 @@ end
         """ * J.EOS
 
     @test (@test_logs (:warn, "Eval of non-julia code blocks is not supported at the moment") h |> seval) == "<p>Simple code: <pre><code class=\"language-python\">sqrt(-1)\n</code></pre> done.</p>\n"
+end
+
+# temporary fix for 186: make error appear and also use `abspath` in internal include
+@testset "eval #186" begin
+    h = raw"""
+        Simple code:
+        ```julia:scripts/test186
+        fn = "tempf.jl"
+        write(fn, "a = 1+1")
+        println("Is this a file? $(isfile(fn))")
+        include(abspath(fn))
+        println("Now: $a")
+        rm(fn)
+        ```
+        done.
+        \output{scripts/test186}
+        """ * J.EOS |> seval
+    @test isapproxstr(h, raw"""
+            <p>Simple code: <pre><code class="language-julia">fn = "tempf.jl"
+            write(fn, "a = 1+1")
+            println("Is this a file? $(isfile(fn))")
+            include(abspath(fn))
+            println("Now: $a")
+            rm(fn)</code></pre> done. <pre><code>Is this a file? true
+            Now: 2
+            </code></pre></p>
+            """)
 end


### PR DESCRIPTION
#186 

- shows the error so that:

````markdown
```julia:script/test
sqrt(-1)
```
\output{script/test}
````

gives 

```html
<pre><code class="language-julia">sqrt(-1)</code></pre> <pre><code>There was an error running the code: DomainError(-1.0, "sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).").</code></pre>
```

which can help for debugging.
