### PR TITLE
Add nicer status messages when something printed meanwhile

### DIFF
--- a/src/manager/judoc.jl
+++ b/src/manager/judoc.jl
@@ -38,7 +38,8 @@ function serve(; clear::Bool=true, verb::Bool=false, port::Int=8000, single::Boo
     start = time()
     sig = jd_fullpass(watched_files; clear=clear, verb=verb, prerender=prerender, isoptim=isoptim)
     sig < 0 && return sig
-    verb && (print(rpad("\n✔ full pass...", 40)); time_it_took(start); println(""))
+    fmsg = rpad("✔ full pass...", 40)
+    verb && (println(""); print(fmsg); printend(fmsg, start); println(""))
 
     # start the continuous loop
     if !single
@@ -179,16 +180,19 @@ function jd_loop(cycle_counter::Int, ::LiveServer.FileWatcher, watched_files::Na
             cur_t = mtime(fpath)
             cur_t <= t && continue
             # if there was then the file has been modified and should be re-processed + copied
-            verb && print(rpad("→ file $(fpath[length(FOLDER_PATH[])+1:end]) was modified ", 30))
+            fmsg = rpad("→ file $(fpath[length(FOLDER_PATH[])+1:end]) was modified ", 30)
+            verb && print(fmsg)
             dict[fpair] = cur_t
             # if it's an infra_file
             if haskey(watched_files[:infra], fpair)
+                #TODO: couldn't test this branch
                 verb && println("→ full pass...")
                 start = time()
                 jd_fullpass(watched_files; clear=false, verb=false, prerender=false)
-                verb && (print(rpad("\n✔ full pass...", 15)); time_it_took(start); println(""))
+                verb && (printend(rpad("✔ full pass...", 15), start); println(""))
             else
-                verb && print(rpad("→ updating... ", 15))
+                fmsg = fmsg * rpad("→ updating... ", 15)
+                verb && print("\r" * fmsg)
                 start = time()
                 # TODO, ideally these would only be read if they've changed. Not super important
                 # but just not necessary. (Fixing may be a bit of a pain though)
@@ -196,7 +200,7 @@ function jd_loop(cycle_counter::Int, ::LiveServer.FileWatcher, watched_files::Na
                 pg_foot = read(joinpath(PATHS[:src_html], "page_foot.html"), String)
                 foot    = read(joinpath(PATHS[:src_html], "foot.html"), String)
                 process_file(case, fpair, head, pg_foot, foot, cur_t; clear=false, prerender=false)
-                verb && time_it_took(start)
+                verb && printend(fmsg, start)
             end
         end
     end

--- a/src/manager/judoc.jl
+++ b/src/manager/judoc.jl
@@ -39,7 +39,7 @@ function serve(; clear::Bool=true, verb::Bool=false, port::Int=8000, single::Boo
     sig = jd_fullpass(watched_files; clear=clear, verb=verb, prerender=prerender, isoptim=isoptim)
     sig < 0 && return sig
     fmsg = rpad("✔ full pass...", 40)
-    verb && (println(""); print(fmsg); printend(fmsg, start); println(""))
+    verb && (println(""); print(fmsg); print_final(fmsg, start); println(""))
 
     # start the continuous loop
     if !single
@@ -189,7 +189,7 @@ function jd_loop(cycle_counter::Int, ::LiveServer.FileWatcher, watched_files::Na
                 verb && println("→ full pass...")
                 start = time()
                 jd_fullpass(watched_files; clear=false, verb=false, prerender=false)
-                verb && (printend(rpad("✔ full pass...", 15), start); println(""))
+                verb && (print_final(rpad("✔ full pass...", 15), start); println(""))
             else
                 fmsg = fmsg * rpad("→ updating... ", 15)
                 verb && print("\r" * fmsg)
@@ -200,7 +200,7 @@ function jd_loop(cycle_counter::Int, ::LiveServer.FileWatcher, watched_files::Na
                 pg_foot = read(joinpath(PATHS[:src_html], "page_foot.html"), String)
                 foot    = read(joinpath(PATHS[:src_html], "foot.html"), String)
                 process_file(case, fpair, head, pg_foot, foot, cur_t; clear=false, prerender=false)
-                verb && printend(fmsg, start)
+                verb && print_final(fmsg, start)
             end
         end
     end

--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -36,7 +36,7 @@ function optimize(; prerender::Bool=true, minify::Bool=true, sig::Bool=false,
     withpre = fmsg * ifelse(prerender, rpad(" (with pre-rendering)", 24), rpad(" (no pre-rendering)", 24))
     print(withpre)
     succ = (serve(single=true, prerender=prerender, nomess=true, isoptim=true) === nothing)
-    printend(withpre, start)
+    print_final(withpre, start)
 
     #
     # Minification
@@ -52,7 +52,7 @@ function optimize(; prerender::Bool=true, minify::Bool=true, sig::Bool=false,
             succ = success(`$([e for e in split(PY)]) $JD_PY_MIN_NAME`)
             # remove the script file
             rm(JD_PY_MIN_NAME)
-            printend(mmsg, start)
+            print_final(mmsg, start)
         else
             @warn "I didn't find css_html_js_minify, you can install it via pip the output will "*
                   "not be minified."
@@ -90,7 +90,7 @@ function publish(; prerender::Bool=true, minify::Bool=true, nopass::Bool=false,
             run(`git add -A `)
             run(`git commit -m "jd-update" --quiet`)
             run(`git push --quiet`)
-            printend(pubmsg, start)
+            print_final(pubmsg, start)
         catch e
             println("✘ Could not push updates, verify your connection and try manually.\n")
             @show e

--- a/src/manager/post_processing.jl
+++ b/src/manager/post_processing.jl
@@ -31,11 +31,12 @@ function optimize(; prerender::Bool=true, minify::Bool=true, sig::Bool=false,
     end
     # re-do a (silent) full pass
     start = time()
-    print("→ Full pass")
-    withpre = ifelse(prerender, rpad(" (with pre-rendering)", 24), rpad(" (no pre-rendering)", 24))
+    fmsg = "\r→ Full pass"
+    print(fmsg)
+    withpre = fmsg * ifelse(prerender, rpad(" (with pre-rendering)", 24), rpad(" (no pre-rendering)", 24))
     print(withpre)
     succ = (serve(single=true, prerender=prerender, nomess=true, isoptim=true) === nothing)
-    time_it_took(start)
+    printend(withpre, start)
 
     #
     # Minification
@@ -43,14 +44,15 @@ function optimize(; prerender::Bool=true, minify::Bool=true, sig::Bool=false,
     if minify && succ
         if JD_CAN_MINIFY
             start = time()
-            print(rpad("→ Minifying *.[html|css] files...", 35))
+            mmsg = rpad("→ Minifying *.[html|css] files...", 35)
+            print(mmsg)
             # copy the script to the current dir
             cp(joinpath(dirname(pathof(JuDoc)), "scripts", "minify.py"), JD_PY_MIN_NAME; force=true)
             # run it
             succ = success(`$([e for e in split(PY)]) $JD_PY_MIN_NAME`)
             # remove the script file
             rm(JD_PY_MIN_NAME)
-            time_it_took(start)
+            printend(mmsg, start)
         else
             @warn "I didn't find css_html_js_minify, you can install it via pip the output will "*
                   "not be minified."
@@ -82,12 +84,13 @@ function publish(; prerender::Bool=true, minify::Bool=true, nopass::Bool=false,
     end
     if succ
         start = time()
-        print(rpad("→ Pushing updates with git...", 35))
+        pubmsg = rpad("→ Pushing updates with git...", 35)
+        print(pubmsg)
         try
             run(`git add -A `)
             run(`git commit -m "jd-update" --quiet`)
             run(`git push --quiet`)
-            time_it_took(start)
+            printend(pubmsg, start)
         catch e
             println("✘ Could not push updates, verify your connection and try manually.\n")
             @show e
@@ -109,14 +112,16 @@ function cleanpull()::Nothing
     FOLDER_PATH[] = pwd()
     set_paths!()
     if isdir(PATHS[:pub])
-        print(rpad("→ Removing local output dir...", 35))
+        rmmsg = rpad("→ Removing local output dir...", 35)
+        print(rmmsg)
         rm(PATHS[:pub], force=true, recursive=true)
-        println(" [done ✔ ]")
+        println("\r" * rmmsg * " [done ✔ ]")
     end
     try
-        print(rpad("→ Retrieving updates from the repository...", 35))
+        pmsg = rpad("→ Retrieving updates from the repository...", 35)
+        print(pmsg)
         run(`git pull --quiet`)
-        println(" [done ✔ ]")
+        println("\r" * pmsg * " [done ✔ ]")
     catch e
         println("✘ Could not pull updates, verify your connection and try manually.\n")
         @show e

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -88,13 +88,22 @@ $(SIGNATURES)
 
 Convenience function to display a time since `start`.
 """
-function time_it_took(start::Float64)::Nothing
+function time_it_took(start::Float64)
     comp_time = time() - start
     mess = comp_time > 60 ? "$(round(comp_time/60;   digits=1))m" :
            comp_time >  1 ? "$(round(comp_time;      digits=1))s" :
                             "$(round(comp_time*1000; digits=1))ms"
-    println("[done $(lpad(mess, 6))]")
-    return nothing
+    return "[done $(lpad(mess, 6))]"
+end
+
+```
+$(SIGNATURES)
+
+Nicer printing of processes.
+```
+function printend(startmsg::AbstractString, starttime::Float64)::Nothing
+    tit = time_it_took(starttime)
+    println("\r$startmsg$tit")
 end
 
 

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -101,7 +101,7 @@ $(SIGNATURES)
 
 Nicer printing of processes.
 ```
-function printend(startmsg::AbstractString, starttime::Float64)::Nothing
+function print_final(startmsg::AbstractString, starttime::Float64)::Nothing
     tit = time_it_took(starttime)
     println("\r$startmsg$tit")
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -67,7 +67,7 @@ end
     f = joinpath(d, "a.txt")
     open(f, "w") do outf
         redirect_stdout(outf) do
-            J.time_it_took(start)
+            J.printend("elapsing",start)
         end
     end
     r = read(f, String)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -67,7 +67,7 @@ end
     f = joinpath(d, "a.txt")
     open(f, "w") do outf
         redirect_stdout(outf) do
-            J.printend("elapsing",start)
+            J.print_final("elapsing",start)
         end
     end
     r = read(f, String)


### PR DESCRIPTION
This is again a minor issue, but status messages are not so nice when something is printed between the beginning and the end. Consider the following example:
```
# no password for the SSH key pair
julia> cleanpull()
→ Retrieving updates from the repository... [done ✔ ]

# setting password for the SSH key pair.

julia> cleanpull()
→ Retrieving updates from the repository...Enter passphrase for key '/c/Users/cstamas/.ssh/ssh_id':
 [done ✔ ]
```
I think the latter is not so nice, we can do better. In this PR I suggest a solution, which is basically "saving" the beginning of the status, then printing the whole message again, something like:
```julia
msg = "git command ..."
print(msg)
run(`git pull`)
println("\r" * msg * "[done]")
```


Two usecases I encountered:
* SSH password when git commands run,
* precompilation info strings.

## Git passwords

### On master
```
julia> cleanpull()
→ Retrieving updates from the repository...Enter passphrase for key '/c/Users/cstamas/.ssh/ssh_id':
 [done ✔ ]

julia> publish()
→ Full pass (with pre-rendering)   [done   2.0s]
→ Minifying *.[html|css] files...  [done 778.0ms]
→ Pushing updates with git...      warning: LF will be replaced by CRLF in assets/rundiary/load.jl.
The file will have its original line endings in your working directory
Enter passphrase for key '/c/Users/cstamas/.ssh/id_ed25519':
[done   7.7s]
```

### With this patch

```
julia> cleanpull()
→ Removing local output dir...      [done ✔ ]
→ Retrieving updates from the repository...Enter passphrase for key '/c/Users/cstamas/.ssh/ssh_id':
→ Retrieving updates from the repository... [done ✔ ]

julia> publish()
→ Full pass (with pre-rendering)   [done   2.6s]
→ Minifying *.[html|css] files...  [done 896.0ms]
→ Pushing updates with git...      warning: LF will be replaced by CRLF in assets/rundiary/load.jl.
The file will have its original line endings in your working directory
Enter passphrase for key '/c/Users/cstamas/.ssh/ssh_id':
→ Pushing updates with git...      [done   5.6s]
```

## Recompilation messages

Tested with an example repo, containing a small script with the `ZChop.jl` package. (The script is something like: `using ZChop; a = zchop(1.000001); println(a)`.

### On master
```
julia> publish()
→ Full pass (with pre-rendering)   [ Info: Recompiling stale cache file C:\Users\cstamas\.julia\compiled\v1.1\ZChop\cSx6d.ji for ZChop [8603256b-76ad-53fe-b511-38a38e6437cd]
[done   9.2s]
→ Minifying *.[html|css] files...  [done 428.0ms]
→ Pushing updates with git...      warning: LF will be replaced by CRLF in Testike/assets/pages/code/ex2.jl.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in Testike/assets/pages/code/ex3.jl.
...
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in Testike/assets/pages/code/output/ex2.out.
Enter passphrase for key '/c/Users/cstamas/.ssh/ssh_id':
[done   7.9s]
```

### With this patch

```
julia> publish()
→ Full pass (with pre-rendering)   [ Info: Recompiling stale cache file C:\Users\cstamas\.julia\compiled\v1.1\ZChop\cSx6d.ji for ZChop [8603256b-76ad-53fe-b511-38a38e6437cd]
→ Full pass (with pre-rendering)   [done   8.1s]
→ Minifying *.[html|css] files...  [done 405.0ms]
→ Pushing updates with git...      warning: LF will be replaced by CRLF in Testike/assets/pages/code/ex2.jl.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in Testike/assets/pages/code/ex3.jl.
...
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in Testike/assets/pages/code/output/ex2.out.
Enter passphrase for key '/c/Users/cstamas/.ssh/ssh_id':
→ Pushing updates with git...      [done   6.0s]
```

I think this way the messages are clearer and nicer, hope you like it too.