### PR TITLE
resolve highlight.js installation instruction 

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,9 +47,6 @@ Assuming you have those, you will then need to install `highlight.js` via `npm`:
 [sudo] npm install -g highlight.js
 ```
 
-On Windows you _may_ need to add the following to your environment variables ([source](https://stackoverflow.com/a/26480275)):
-`NODE_PATH=%AppData%\npm\node_modules`
-
 and the python package [`css_html_js_minify`](https://github.com/juancarlospaco/css-html-js-minify) which you can install with `pip3` (if you have python3, JuDoc will try to do this for you):
 
 ```bash
@@ -79,7 +76,7 @@ true
 
     These external dependencies are **not required** to run JuDoc, they are just recommended to benefit from some of the post-processing machinery such as [`optimize`](@ref) or [`publish`](@ref).
 
-**Troubleshooting**:
+### Troubleshooting
 
 If JuDoc complains that it can't find a dependency while you believe that it is installed on your computer, you may have to help JuDoc know how to call the dependency.
 For this, you can specify in your `.julia/config/startup.jl`:
@@ -100,6 +97,13 @@ true
 julia> success(`node -v`)
 true
 ```
+
+#### Highlight.js
+
+If you have issues with getting highlight.js to work, you should give these a try:
+
+* On Windows you _may_ need to add the following to your environment variables ([source](https://stackoverflow.com/a/26480275)): `NODE_PATH=%AppData%\npm\node_modules`
+* You _may_ need to use the `--save` switch ([source](https://stackoverflow.com/a/30886703)): `[sudo] npm install -g --save highlight.js`
 
 ## Quick start
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,7 +47,8 @@ Assuming you have those, you will then need to install `highlight.js` via `npm`:
 [sudo] npm install -g highlight.js
 ```
 
-(you _may_ need to add `--save` to make this work well, see if the tests below work and if not, try again with `--save`)
+On Windows you _may_ need to add the following to your environment variables ([source](https://stackoverflow.com/a/26480275)):
+`NODE_PATH=%AppData%\npm\node_modules`
 
 and the python package [`css_html_js_minify`](https://github.com/juancarlospaco/css-html-js-minify) which you can install with `pip3` (if you have python3, JuDoc will try to do this for you):
 


### PR DESCRIPTION
Again... I tried to set up `highlight.js` and the proposed advice (#178) did not work, so searched a bit more. [What I've found](https://stackoverflow.com/a/26480275) is the following: putting the `node_modules` folder in an environment variable. I tested it with removing-reinstalling (and trying with other suggestions too) and this one worked.
If this works for @mbaz too, that would be a good confirmation.