### PR TITLE
Mdfix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,10 @@ LiveServer = ">= 0.3.0"
 julia = "^1.0.0"
 
 [extras]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "LinearAlgebra"]
+test = ["Test", "DataStructures", "Random", "LinearAlgebra"]

--- a/docs/src/lib/design.md
+++ b/docs/src/lib/design.md
@@ -109,7 +109,7 @@ For instance, let's consider markdown tokens that start with `@`:
 '@' => [
      isexactly("@def", [' '])  => :MD_DEF_OPEN,
      isexactly("@@", SPACER)   => :DIV_CLOSE,
-     incrlook((i, c) -> ifelse(i==1, c=='@', α(c, ['-']))) => :DIV_OPEN ],
+     incrlook((i, c) -> ifelse(i==1, c=='@', α(c, ('-',)))) => :DIV_OPEN ],
 ```
 
 The vector of `TokenFinder` contains three rules:

--- a/src/JuDoc.jl
+++ b/src/JuDoc.jl
@@ -67,6 +67,7 @@ include("parser/lx_tokens.jl")
 include("parser/lx_blocks.jl")
 # > markdown
 include("parser/md_tokens.jl")
+include("parser/md_chars.jl")
 # > html
 include("parser/html_tokens.jl")
 include("parser/html_blocks.jl")

--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -5,13 +5,15 @@ Helper function for `convert_inter_html` that processes an extracted block given
 `lxc` and returns the processed html that needs to be plugged in the final html.
 """
 function convert_block(β::AbstractBlock, lxcontext::LxContext)::AbstractString
+    # case for special characters / html entities
+    β isa HTML_SPCH     && return ifelse(isempty(β.r), β.ss, β.r)
+
     # Return relevant interpolated string based on case
     βn = β.name
     βn ∈  MD_HEADER     && return convert_header(β)
-    βn == :LINE_SKIP    && return "<p></p>"
-    βn == :CODE_INLINE  && return md2html(β.ss, true)
+    βn == :CODE_INLINE  && return md2html(β.ss; stripp=true, code=true)
     βn == :CODE_BLOCK_L && return convert_code_block(β.ss)
-    βn == :CODE_BLOCK   && return md2html(β.ss)
+    βn == :CODE_BLOCK   && return md2html(β.ss; code=true)
     βn == :ESCAPE       && return chop(β.ss, head=3, tail=3)
 
     # Math block --> needs to call further processing to resolve possible latex

--- a/src/converter/md_utils.jl
+++ b/src/converter/md_utils.jl
@@ -6,11 +6,11 @@ that don't need to be further considered and don't contain anything else than ma
 The boolean `stripp` indicates whether to remove the inserted `<p>` and `</p>` by the base markdown
 processor, this is relevant for things that are parsed within latex commands etc.
 """
-function md2html(ss::AbstractString, stripp::Bool=false)::AbstractString
+function md2html(ss::AbstractString; stripp::Bool=false, code::Bool=false)::AbstractString
     isempty(ss) && return ss
 
     # Use the base Markdown -> Html converter and post process headers
-    partial = ss |> fix_inserts |> Markdown.parse |> Markdown.html |> fix_lineskips
+    partial = ss |> fix_inserts |> Markdown.parse |> Markdown.html
 
     # In some cases, base converter adds <p>...</p>\n which we might not want
     stripp || return partial
@@ -81,11 +81,3 @@ extraneous whitespace.
 fix_inserts(s::AbstractString)::String =
     replace(replace(s, r"([\*_]) ##JDINSERT##" => s"\1##JDINSERT##"),
                        r"##JDINSERT## ([\*_])" => s"##JDINSERT##\1")
-
-
-"""
-$(SIGNATURES)
-
-Allow the use of latex-like `\\` to force a line skip.
-"""
-fix_lineskips(s::AbstractString)::String = replace(s, r"\\\\" => "<br/>")

--- a/src/migration/jekyll.jl
+++ b/src/migration/jekyll.jl
@@ -1,0 +1,48 @@
+# XXX WIP
+# also can read the specs in https://daringfireball.net/projects/markdown/syntax
+# and see how to use them / extend them
+
+# NOTE
+# * quoting a block of code does not work well (need to check) the following doesn't work: (the >
+# get captured in the code environment)
+# > This is
+# > a quote **with bold** and _emphasis_ and `code`
+# > ```julia
+# > x=5
+# > x+1
+# > ```
+
+# ======
+# GRUBER markdown (specified https://daringfireball.net/projects/markdown/syntax)
+# -- horizontal rules; ***, *****, or -------------- will work but not * * * or - - -
+# ======
+
+
+"""
+$SIGNATURES
+
+Helps convert a markdown file used in a Jekyll setting to one that can be used in a JuDoc one.
+It takes a string, applies standard fixes, and outputs a modified string that can be saved to file.
+"""
+function migrate_md(src::AbstractString)
+
+    # Main ones:
+    # --> code may be indented with quadruple space or 1 tab; a code block continues until
+    # it reaches a line that is not indented (or the end of the article).
+
+    # Minor ones:
+    # --> find --- ... --- (header information) [Jekyll?]
+    # --> people may use [...]: ... for link references interchangeably with [blah](link)
+    # --> find `&...;` (html entities) and add a `\` in front and treat that as a `~~~.~~~`.
+
+
+    return src
+end
+
+# function migrate(src::AbstractString, dest::String=""; format="jekyll")
+#     isfile(src) || throw(ArgumentError("File $src not found."))
+#
+#     isempty(dest) && # ...
+# end
+
+# function migrate(folder)

--- a/src/parser/md_chars.jl
+++ b/src/parser/md_chars.jl
@@ -1,0 +1,27 @@
+"""
+$SIGNATURES
+
+Take a list of token and return those corresponding to special characters or html entities wrapped
+in `HTML_SPCH` types (will be left alone by the markdown conversion and be inserted as is in the
+HTML).
+"""
+function find_special_chars(tokens::Vector{Token})
+    spch = Vector{HTML_SPCH}()
+    isempty(tokens) && return spch
+    for τ in tokens
+        τ.name == :CHAR_BACKSPACE   && push!(spch, HTML_SPCH(τ.ss, "&#92;"))
+        τ.name == :CHAR_BACKTICK    && push!(spch, HTML_SPCH(τ.ss, "&#96;"))
+        τ.name == :CHAR_LINEBREAK   && push!(spch, HTML_SPCH(τ.ss, "<br/>"))
+        τ.name == :CHAR_HTML_ENTITY && verify_html_entity(τ.ss) && push!(spch, HTML_SPCH(τ.ss))
+    end
+    return spch
+end
+
+"""
+$SIGNATURES
+
+Verify that a given string corresponds to a well formed html entity.
+"""
+function verify_html_entity(ss::AbstractString)
+    match(r"&(?:[a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});", ss) !== nothing
+end

--- a/test/_jekyll_conversion/put-this-in-your-pipe/original.md
+++ b/test/_jekyll_conversion/put-this-in-your-pipe/original.md
@@ -1,0 +1,266 @@
+---
+layout: post
+title:  Shelling Out Sucks
+author: <a href="http://karpinski.org/">Stefan Karpinski</a>
+---
+
+[followup post]: /blog/2013/04/put-this-in-your-pipe
+
+[Perl]:     http://www.perl.org/
+[Python]:   http://python.org/
+[Ruby]:     http://www.ruby-lang.org/
+[Bash]:     http://www.gnu.org/software/bash/
+
+Spawning a pipeline of connected programs via an intermediate shell — a.k.a. "shelling out" — is a really convenient and effective way to get things done.
+It's so handy that some "[glue languages](http://en.wikipedia.org/wiki/Glue_language)," like [Perl] and [Ruby], even have special syntax for it (backticks).
+However, shelling out is also a common source of bugs, security holes, unnecessary overhead, and silent failures.
+Here are the three reasons why shelling out is problematic:
+
+1. *[Metacharacter brittleness.](#Metacharacter+Brittleness)*
+When commands are constructed programmatically, the resulting code is almost always brittle:
+if a variable used to construct the command contains any shell metacharacters, including spaces, the command will likely break and do something very different than what was intended — potentially something quite dangerous.
+3. *[Indirection and inefficiency.](#Indirection+and+Inefficiency)*
+When shelling out, the main program forks and execs a shell process just so that the shell can in turn fork and exec a series of commands with their inputs and outputs appropriately connected.
+Not only is starting a shell an unnecessary step, but since the main program is not the parent of the pipeline commands, it cannot be notified when they terminate — it can only wait for the pipeline to finish and hope the shell indicates what happened.
+2. *[Silent failures by default.](#Silent+Failures+by+Default)*
+Errors in shelled out commands don't automatically become exceptions in most languages.
+This default leniency leads to code that fails silently when shelled out commands don't work.
+Worse still, because of the indirection problem, there are many cases where the failure of a process in a spawned pipeline *cannot* be detected by the parent process, even if errors are fastidiously checked for.
+
+In the rest of this post, I'll go over examples demonstrating each of these problems.
+At [the end](#Summary+and+Remedy), I'll talk about better alternatives to shelling out, and in a [followup post](http://julialang.org/blog/2013/04/put-this-in-your-pipe). I'll demonstrate how Julia makes these better alternatives dead simple to use.
+Examples below are given in Ruby which shells out to [Bash], but the same problems exist no matter what language one shells out from:
+it's the technique of using an intermediate shell process to spawn external commands that's at fault, not the language.
+
+## Metacharacter Brittleness
+
+Let's start with a simple example of shelling out from Ruby.
+Suppose you want to count the number of lines containing the string "foo" in all the files under a directory given as an argument.
+One option is to write Ruby code that reads the contents of the given directory, finds all the files, opens them and iterates through them looking for the string "foo".
+However, that's a lot of work and it's going to be much slower than using a pipeline of standard UNIX commands, which are written in C and heavily optimized.
+The most natural and convenient thing to do in Ruby is to shell out, using backticks to capture output:
+
+    `find #{dir} -type f -print0 | xargs -0 grep foo | wc -l`.to_i
+
+This expression interpolates the `dir` variable into a command, spawns a Bash shell to execute the resulting command, captures the output into a string, and then converts that string to an integer.
+The command uses the `-print0` and `-0` options to correctly handle strange characters in file names piped from `find` to `xargs` (these options cause file names to be delimited by [NULs](http://en.wikipedia.org/wiki/Null_character) instead of whitespace).
+Even with extra-careful options, this code for shelling out is simple and clear.
+Here it is in action:
+
+    irb(main):001:0> dir="src"
+    => "src"
+    irb(main):002:0> `find #{dir} -type f -print0 | xargs -0 grep foo | wc -l`.to_i
+    => 5
+
+Great.
+However, this only works as expected if the directory name `dir` doesn't contain any characters that the shell considers special.
+For example, the shell decides what constitutes a single argument to a command using whitespace.
+Thus, if the value of `dir` is a directory name containing a space, this will fail:
+
+    irb(main):003:0> dir="source code"
+    => "source code"
+    irb(main):004:0> `find #{dir} -type f -print0 | xargs -0 grep foo | wc -l`.to_i
+    find: `source': No such file or directory
+    find: `code': No such file or directory
+    => 0
+
+The simple solution to the problem of spaces is to surround the interpolated directory name in quotes, telling the shell to treat spaces inside as normal characters:
+
+    irb(main):005:0> `find '#{dir}' -type f -print0 | xargs -0 grep foo | wc -l`.to_i
+    => 5
+
+Excellent.
+So what's the problem?
+While this solution addresses the issue of file names with spaces in them, it is still brittle with respect to other shell metacharacters.
+What if a file name has a quote character in it?
+Let's try it.
+First, let's create a very weirdly named directory:
+
+    bash-3.2$ mkdir "foo'bar"
+    bash-3.2$ echo foo > "foo'bar"/test.txt
+    bash-3.2$ ls -ld foo*bar
+    drwxr-xr-x 3 stefan staff 102 Feb  3 16:17 foo'bar/
+
+That's an admittedly strange directory name, but it's perfectly legal in UNIXes of all flavors.
+Now back to Ruby:
+
+    irb(main):006:0> dir="foo'bar"
+    => "foo'bar"
+    irb(main):007:0> `find '#{dir}' -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+    sh: -c: line 0: unexpected EOF while looking for matching `''
+    sh: -c: line 1: syntax error: unexpected end of file
+    => 0
+
+Doh.
+Although this may seem like an unlikely corner case that one needn't realistically worry about, there are serious security ramifications.
+Suppose the name of the directory came from an untrusted source — like a web submission, or an argument to a setuid program from an untrusted user.
+Suppose an attacker could arrange for any value of `dir` they wanted:
+
+    irb(main):008:0> dir="foo'; echo MALICIOUS ATTACK 1>&2; echo '"
+    => "foo'; echo MALICIOUS ATTACK 1>&2; echo '"
+    irb(main):009:0> `find '#{dir}' -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+    find: `foo': No such file or directory
+    MALICIOUS ATTACK
+    grep:  -type f -print0
+    : No such file or directory
+    => 0
+
+Your box is now owned.
+Of course, you could sanitize the value of the `dir` variable, but there's a fundamental tug-of-war between security (as limited as possible) and flexibility (as unlimited as possible).
+The ideal behavior is to allow any directory name, no matter how bizarre, as long as it actually exists, but "defang" all shell metacharacters.
+
+The only two way to fully protect against these sorts of metacharacter attacks — whether malicious or accidental — while still using an external shell to construct the pipeline, is to do full shell metacharacter escaping:
+
+    irb(main):010:0> require 'shellwords'
+    => true
+    irb(main):011:0> `find #{Shellwords.shellescape(dir)} -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+    find: `foo\'; echo MALICIOUS ATTACK 1>&2; echo \'': No such file or directory
+    => 0
+
+With shell escaping, this safely attempts to search a very oddly named directory instead of executing the malicious attack.
+Although shell escaping does work (assuming that there aren't any mistakes in the shell escaping implementation), realistically, no one actually bothers — it's too much trouble.
+Instead, code that shells out with programmatically constructed commands is typically riddled with potential bugs in the best case and massive security holes in the worst case.
+
+## Indirection and Inefficiency
+
+If we were using the above code to count the number of lines with the string "foo" in a directory, we would want to check to see if everything worked and respond appropriately if something went wrong.
+In Ruby, you can check if a shelled out command was successful using the bizarrely named `$?.success?` indicator:
+
+    irb(main):012:0> dir="src"
+    => "src"
+    irb(main):013:0> `find #{Shellwords.shellescape(dir)} -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+    => 5
+    irb(main):014:0> $?.success?
+    => true
+
+Ok, that correctly indicates success.
+Let's make sure that it can detect failure:
+
+    irb(main):015:0> dir="nonexistent"
+    => "nonexistent"
+    irb(main):016:0> `find #{Shellwords.shellescape(dir)} -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+    find: `nonexistent': No such file or directory
+    => 0
+    irb(main):017:0> $?.success?
+    => true
+
+Wait. What?!
+That wasn't successful.
+What's going on?
+
+The heart of the problem is that when you shell out, the commands in the pipeline are not immediate children of the main program, but rather its grandchildren:
+the program spawns a shell, which makes a bunch of UNIX pipes, forks child processes, connects inputs and outputs to pipes using the [`dup2` system call](https://developer.apple.com/library/IOs/#documentation/System/Conceptual/ManPages_iPhoneOS/man2/dup2.2.html), and then execs the appropriate commands.
+As a result, your main program is not the parent of the commands in the pipeline, but rather, their grandparent.
+Therefore, it doesn't know their process IDs, nor can it wait on them or get their exit statuses when they terminate.
+The shell process, which is their parent, has to do all of that.
+Your program can only wait for the shell to finish and see if *that* was successful.
+If the shell is only executing a single command, this is fine:
+
+    irb(main):018:0> `cat /dev/null`
+    => ""
+    irb(main):019:0> $?.success?
+    => true
+    irb(main):020:0> `cat /dev/nada`
+    cat: /dev/nada: No such file or directory
+    => ""
+    irb(main):021:0> $?.success?
+    => false
+
+Unfortunately, by default the shell is quite lenient about what it considers to be a successful pipeline:
+
+    irb(main):022:0> `cat /dev/nada | sort`
+    cat: /dev/nada: No such file or directory
+    => ""
+    irb(main):023:0> $?.success?
+    => true
+
+As long as the last command in a pipeline succeeds — in this case `sort` — the entire pipeline is considered a success.
+Thus, even when one or more of the earlier programs in a pipeline fails spectacularly, the last command may not, leading the shell to consider the entire pipeline to be successful.
+This is probably not what you meant by success.
+
+Bash's notion of pipeline success can fortunately be made stricter with the `pipefail` option.
+This option causes the shell to consider a pipeline successful only if all of its commands are successful:
+
+    irb(main):024:0> `set -o pipefail; cat /dev/nada | sort`
+    cat: /dev/nada: No such file or directory
+    => ""
+    irb(main):025:0> $?.success?
+    => false
+
+Since shelling out spawns a new shell every time, this option has to be set for every multi-command pipeline in order to be able to determine its true success status.
+Of course, just like shell-escaping every interpolated variable, setting `pipefail` at the start of every command is simply something that no one actually does.
+Moreover, even with the `pipefail` option, your program has no way of determining *which* commands in a pipeline were unsuccessful — it just knows that something somewhere went wrong.
+While that's better than silently failing and continuing as if there were no problem, its not very helpful for postmortem debugging:
+many programs are not as well-behaved as `cat` and don't actually identify themselves or the specific problem when printing error messages before going belly up.
+
+Given the other problems caused by the indirection of shelling out, it seems like a barely relevant afterthought to mention that execing a shell process just to spawn a bunch of other processes is inefficient.
+However, it is a real source of unnecessary overhead:
+the main process could just do the work the shell does itself.
+Asking the kernel to fork a process and exec a new program is a non-trivial amount of work.
+The only reason to have the shell do this work for you is that it's complicated and hard to get right.
+The shell makes it easy.
+So programming languages have traditionally relied on the shell to setup pipelines for them, regardless of the additional overhead and problems caused by indirection.
+
+## Silent Failures by Default
+
+Let's return to our example of shelling out to count "foo" lines.
+Here's the total expression we need to use in order to shell out without being susceptible to metacharacter breakage and so we can actually tell whether the entire pipeline succeeded:
+
+    `set -o pipefail; find #{Shellwords.shellescape(dir)} -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+
+However, an error isn't raised by default when a shelled out command fails.
+To avoid silent errors, we need to explicitly check `$?.success?` after every time we shell out and raise an exception if it indicates failure.
+Of course, doing this manually is tedious, and as a result, it largely isn't done.
+The default behavior — and therefore the easiest and most common behavior — is to assume that shelled out commands worked and completely ignore failures.
+To make our "foo" counting example well-behaved, we would have to wrap it in a function like so:
+
+    def foo_count(dir)
+      n = `set -o pipefail;
+           find #{Shellwords.shellescape(dir)} -type f -print0  | xargs -0 grep foo | wc -l`.to_i
+      raise("pipeline failed") unless $?.success?
+      return n
+    end
+
+This function behaves the way we would like it to:
+
+    irb(main):026:0> foo_count("src")
+    => 5
+    irb(main):027:0> foo_count("source code")
+    => 5
+    irb(main):028:0> foo_count("nonexistent")
+    find: `nonexistent': No such file or directory
+    RuntimeError: pipeline failed
+    	from (irb):5:in `foo_count'
+    	from (irb):13
+    	from :0
+    irb(main):029:0> foo_count("foo'; echo MALICIOUS ATTACK; echo '")
+    find: `foo\'; echo MALICIOUS ATTACK; echo \'': No such file or directory
+    RuntimeError: pipeline failed
+    	from (irb):5:in `foo_count'
+    	from (irb):14
+    	from :0
+
+However, this 6-line, 200-character function is a far cry from the clarity and brevity we started with:
+
+    `find #{dir} -type f -print0 | xargs -0 grep foo | wc -l`.to_i
+
+If most programmers saw the longer, safer version of this in a program, they'd probably wonder why someone was writing such verbose, cryptic code to get something so simple and straightforward done.
+
+## Summary and Remedy
+
+To sum it up, shelling out is great, but making code that shells out bug-free, secure, and not prone to silent failures requires three things that typically aren't done:
+
+1. Shell-escaping all values used to construct commands
+2. Prefixing each multi-command pipeline with "`set -o pipefail;`"
+3. Explicitly checking for failure after each shelled out command.
+
+The trouble is that after doing all of these things, shelling out is no longer terribly convenient, and the code becomes annoyingly verbose.
+In short, shelling out responsibly kind of sucks.
+
+As is so often the case, the root of all of these problems is relying on a middleman rather than doing things yourself.
+If a program constructs and executes pipelines itself, it remains in control of all the subprocesses, can determine their individual exit conditions, automatically handle errors appropriately, and give accurate, comprehensive diagnostic messages when things go wrong.
+Moreover, without a shell to interpret commands, there is also no shell to treat metacharacters specially, and therefore no danger of metacharacter brittleness.
+[Python] gets this right:
+using [`os.popen`](http://docs.python.org/library/os.html#os.popen) to shell out is officially deprecated, and the recommended way to call external programs is to use the [`subprocess`](http://docs.python.org/library/subprocess.html) module, which spawns external programs without using a shell.
+Constructing pipelines using `subprocess` [can be a little verbose](http://docs.python.org/library/subprocess.html#replacing-shell-pipeline), but it is safe and avoids all the problems that shelling out is prone to.
+In my [followup post], I will describe how Julia makes constructing and executing pipelines of external commands as safe as Python's `subprocess` and as convenient as shelling out.

--- a/test/converter/markdown2.jl
+++ b/test/converter/markdown2.jl
@@ -1,14 +1,8 @@
 # this follows `markdown.jl` but spurred by bugs/issues
 
 function inter(st::String)
-    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
-    blocks, tokens = J.find_all_ocblocks(tokens, J.MD_OCB_ALL)
-    lxdefs, tokens, braces, blocks = J.find_md_lxdefs(tokens, blocks)
-    lxcoms, _ = J.find_md_lxcoms(tokens, lxdefs, braces)
-    blocks2insert = J.merge_blocks(lxcoms, blocks)
-    inter_md, mblocks = J.form_inter_md(st, blocks2insert, lxdefs)
-    inter_html = J.md2html(inter_md)
-    return inter_md, inter_html
+    steps = explore_md_steps(st)
+    return steps[:inter_md].inter_md, steps[:inter_html].inter_html
 end
 
 @testset "Code+italic (#163)" begin

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -1,3 +1,6 @@
+# NOTE: theses tests focus on speciall characters, html entities
+# escaping things etc.
+
 @testset "Backslashes" begin # see issue #205
     st = raw"""
         Hello \ blah \ end
@@ -37,4 +40,30 @@
                 <pre><code>A \ b</code></pre>
                 done</p>
                 """)
+end
+
+@testset "Backslashes2" begin # see issue #205
+    st = raw"""
+        Hello \ blah \ end
+        and `B \ c` end \\ and
+        ```
+        A \ b
+        ```
+        done
+        """ * J.EOS
+    steps = explore_md_steps(st)
+    tokens, = steps[:tokenization]
+    @test tokens[7].name == :CHAR_LINEBREAK
+    h = st |> seval
+    @test isapproxstr(st |> seval, """
+                        <p>Hello &#92; blah &#92; end
+                        and <code>B \ c</code> end <br/> and
+                        <pre><code>A \ b</code></pre>
+                        done</p>
+                        """)
+end
+
+@testset "Backtick" begin # see issue #205
+    st = raw"""Blah \` etc""" * J.EOS
+    @test isapproxstr(st |> seval, "<p>Blah &#96; etc</p>")
 end

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -7,7 +7,9 @@
         ```
         done
         """ * J.EOS
-    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+
+    steps = explore_md_steps(st)
+    tokens, = steps[:tokenization]
 
     # the first two backspaces are detected
     @test tokens[1].ss == "\\" && tokens[1].name == :CHAR_BACKSPACE
@@ -15,8 +17,7 @@
     # the third one also
     @test tokens[5].ss == "\\" && tokens[5].name == :CHAR_BACKSPACE
 
-    blocks, tokens = J.find_all_ocblocks(tokens, J.MD_OCB_ALL)
-    filter!(τ -> τ.name != :LINE_RETURN, tokens)
+    sp_chars, = steps[:spchars]
 
     # there's only two tokens left which are the backspaces NOT in the code env
     sp_chars = J.find_special_chars(tokens)
@@ -26,9 +27,7 @@
         @test sp_chars[i].r == "&#92;"
     end
 
-    blocks2insert = J.merge_blocks(blocks, sp_chars)
-    inter_md, mblocks = J.form_inter_md(st, blocks2insert, J.LxDef[])
-    inter_html = J.md2html(inter_md)
+    inter_html, = steps[:inter_html]
 
     @test isapproxstr(inter_html, "<p>Hello  ##JDINSERT##  blah  ##JDINSERT##  end and  ##JDINSERT##  end and  ##JDINSERT##  done</p>")
 

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -1,0 +1,41 @@
+@testset "Backslashes" begin # see issue #205
+    st = raw"""
+        Hello \ blah \ end
+        and `B \ c` end and
+        ```
+        A \ b
+        ```
+        done
+        """ * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+
+    # the first two backspaces are detected
+    @test tokens[1].ss == "\\" && tokens[1].name == :CHAR_BACKSPACE
+    @test tokens[2].ss == "\\" && tokens[2].name == :CHAR_BACKSPACE
+    # the third one also
+    @test tokens[5].ss == "\\" && tokens[5].name == :CHAR_BACKSPACE
+
+    blocks, tokens = J.find_all_ocblocks(tokens, J.MD_OCB_ALL)
+    filter!(τ -> τ.name != :LINE_RETURN, tokens)
+
+    # there's only two tokens left which are the backspaces NOT in the code env
+    sp_chars = J.find_special_chars(tokens)
+    for i in 1:2
+        @test sp_chars[i] isa J.HTML_SPCH
+        @test sp_chars[i].ss == "\\"
+        @test sp_chars[i].r == "&#92;"
+    end
+
+    blocks2insert = J.merge_blocks(blocks, sp_chars)
+    inter_md, mblocks = J.form_inter_md(st, blocks2insert, J.LxDef[])
+    inter_html = J.md2html(inter_md)
+
+    @test isapproxstr(inter_html, "<p>Hello  ##JDINSERT##  blah  ##JDINSERT##  end and  ##JDINSERT##  end and  ##JDINSERT##  done</p>")
+
+    @test isapproxstr(st |> seval, raw"""
+                <p>Hello &#92; blah &#92; end
+                and <code>B \ c</code> end and
+                <pre><code>A \ b</code></pre>
+                done</p>
+                """)
+end

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -67,3 +67,11 @@ end
     st = raw"""Blah \` etc""" * J.EOS
     @test isapproxstr(st |> seval, "<p>Blah &#96; etc</p>")
 end
+
+@testset "HTMLEnts" begin # see issue #206
+    st = raw"""Blah &pi; etc""" * J.EOS
+    @test isapproxstr(st |> seval, "<p>Blah &pi; etc</p>")
+    # but ill-formed ones (either deliberately or not) will be parsed
+    st = raw"""AT&T""" * J.EOS
+    @test isapproxstr(st |> seval, "<p>AT&amp;T</p>")
+end

--- a/test/migration/cases1.jl
+++ b/test/migration/cases1.jl
@@ -1,0 +1,41 @@
+# =============================================================
+# Experimenting with Stefan Karpinski's "Shelling out sucks"
+# https://julialang.org/blog/2012/03/shelling-out-sucks
+# =============================================================
+
+# NOTE (quirky things that may be ok one way or the other)
+# - skipping a line in a list --> in jekyll stays part of the same block; not in JuDoc (but that's the julia markdown parser) ==> would require processing lists yourself
+#
+# =============================================================
+
+
+# t1 = process shortcuts for links
+
+st = """
+    [Perl]:     http://www.perl.org/
+    [Python]:   http://python.org/
+
+    (...) like [Perl] and [Ruby].
+    """
+
+# t2 = quadruple spaces at the start of a non-empty line indicate code (like ```) provided the
+# line is preceded by an empty line
+
+st = """
+    Blah
+
+        this is code
+
+    end
+    """
+
+st = """
+    This will fail:
+
+        irb(main):001:0> dir="src"
+        => "src"
+        irb(main):002:0> `find #{dir} -type f -print0 | xargs -0 grep foo | wc -l`.to_i
+        => 5
+
+    The simple
+    """

--- a/test/parser/html.jl
+++ b/test/parser/html.jl
@@ -7,13 +7,13 @@
         show other stuff
         {{ end }}"""
 
-    tokens = JuDoc.find_tokens(st, JuDoc.HTML_TOKENS, JuDoc.HTML_1C_TOKENS)
-    hblocks, tokens = JuDoc.find_all_ocblocks(tokens, J.HTML_OCB)
-    @test hblocks[1].ss == "{{ fill v1 }}"
-    @test hblocks[2].ss == "{{ if b1 }}"
-    @test hblocks[3].ss == "{{ fill v2 }}"
-    @test hblocks[4].ss == "{{ else }}"
-    @test hblocks[5].ss == "{{ end }}"
+    blocks, tokens = explore_h_steps(st)[:ocblocks]
+
+    @test blocks[1].ss == "{{ fill v1 }}"
+    @test blocks[2].ss == "{{ if b1 }}"
+    @test blocks[3].ss == "{{ fill v2 }}"
+    @test blocks[4].ss == "{{ else }}"
+    @test blocks[5].ss == "{{ end }}"
 end
 
 
@@ -27,9 +27,7 @@ end
         {{ end }}
         """
 
-    tokens = JuDoc.find_tokens(st, JuDoc.HTML_TOKENS, JuDoc.HTML_1C_TOKENS)
-    hblocks, tokens = JuDoc.find_all_ocblocks(tokens, J.HTML_OCB)
-    qblocks = JuDoc.qualify_html_hblocks(hblocks)
+    qblocks, = explore_h_steps(st)[:qblocks]
 
     @test qblocks[1].fname == "fill"
     @test qblocks[1].params == ["v1"]
@@ -54,10 +52,7 @@ end
         final text
         """
 
-    tokens = JuDoc.find_tokens(st, JuDoc.HTML_TOKENS, JuDoc.HTML_1C_TOKENS)
-    hblocks, tokens = JuDoc.find_all_ocblocks(tokens, J.HTML_OCB)
-    qblocks = JuDoc.qualify_html_hblocks(hblocks)
-    cblocks, qblocks = JuDoc.find_html_cblocks(qblocks)
+    cblocks,cdblocks,cpblocks,qblocks = explore_h_steps(st)[:cblocks]
 
     @test cblocks[1].init_cond == "b1"
     @test cblocks[1].sec_conds == ["b2"]
@@ -80,12 +75,7 @@ end
         final text
         """
 
-    tokens = JuDoc.find_tokens(st, JuDoc.HTML_TOKENS, JuDoc.HTML_1C_TOKENS)
-    hblocks, tokens = JuDoc.find_all_ocblocks(tokens, J.HTML_OCB)
-    qblocks = JuDoc.qualify_html_hblocks(hblocks)
-    cblocks, qblocks = JuDoc.find_html_cblocks(qblocks)
-    cdblocks, qblocks = JuDoc.find_html_cdblocks(qblocks)
-    hblocks = JuDoc.merge_blocks(qblocks, cblocks, cdblocks)
+    hblocks, = explore_h_steps(st)[:hblocks]
 
     @test hblocks[1].ss == "{{ fill v1 }}"
     @test hblocks[2].ss == "{{ if b1 }}\nshow stuff here {{ fill v2 }}\n{{ elseif b2 }}\nother stuff\n{{ else }}\nshow other stuff\n{{ end }}"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,7 @@ const D = joinpath(dirname(dirname(pathof(JuDoc))), "test", "_dummies")
 # NOTE this first file MUST be included before running the rest of the tests
 # otherwise you may get an error like "key 0x099191234..." was not found or
 # saying that the key :in doesn't exist or something along those lines
-include("jd_paths_vars.jl")
-include("test_utils.jl")
+include("jd_paths_vars.jl"); include("test_utils.jl")
 
 include("misc.jl")
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,3 +1,5 @@
+import DataStructures: OrderedDict
+
 # This set of tests directly uses the high-level `convert` functions
 # And checks the behaviour is as expected.
 
@@ -28,4 +30,70 @@ function seval(st)
     m, _ = J.convert_md(st, collect(values(J.GLOBAL_LXDEFS)))
     h = J.convert_html(m, J.PageVars())
     return h
+end
+
+
+function explore_md_steps(mds)
+    J.def_GLOBAL_PAGE_VARS!()
+    J.def_GLOBAL_LXDEFS!()
+
+    steps = OrderedDict{Symbol,NamedTuple}()
+
+    # tokenize
+    tokens = J.find_tokens(mds, J.MD_TOKENS, J.MD_1C_TOKENS)
+    steps[:tokenization] = (tokens=tokens,)
+
+    # ocblocks
+    blocks, tokens = J.find_all_ocblocks(tokens, J.MD_OCB_ALL)
+    steps[:ocblocks] = (blocks=blocks, tokens=tokens)
+
+    # filter
+    filter!(τ -> τ.name != :LINE_RETURN, tokens)
+    filter!(β -> J.validate_header_block(β), blocks)
+    steps[:filter] = (tokens=tokens, blocks=blocks)
+
+    # latex commands
+    lxdefs, tokens, braces, blocks = J.find_md_lxdefs(tokens, blocks)
+    lxcoms, _ = J.find_md_lxcoms(tokens, lxdefs, braces)
+    steps[:latex] = (lxdefs=lxdefs, tokens=tokens, braces=braces,
+                     blocks=blocks, lxcoms=lxcoms)
+
+    sp_chars = J.find_special_chars(tokens)
+    steps[:spchars] = (spchars=sp_chars,)
+
+    blocks2insert = J.merge_blocks(lxcoms, J.deactivate_divs(blocks), sp_chars)
+    steps[:blocks2insert] = (blocks2insert=blocks2insert,)
+
+    inter_md, mblocks = J.form_inter_md(mds, blocks2insert, lxdefs)
+    steps[:inter_md] = (inter_md=inter_md, mblocks=mblocks)
+
+    inter_html = J.md2html(inter_md; stripp=false)
+    steps[:inter_html] = (inter_html=inter_html,)
+
+    return steps
+end
+
+function explore_h_steps(hs)
+    steps = OrderedDict{Symbol,NamedTuple}()
+
+    tokens = J.find_tokens(hs, J.HTML_TOKENS, J.HTML_1C_TOKENS)
+    steps[:tokenization] = (tokens=tokens,)
+
+    hblocks, tokens = J.find_all_ocblocks(tokens, J.HTML_OCB)
+    filter!(hb -> hb.name != :COMMENT, hblocks)
+    steps[:ocblocks] = (hblocks=hblocks, tokens=tokens)
+
+    qblocks = J.qualify_html_hblocks(hblocks)
+    steps[:qblocks] = (qblocks=qblocks,)
+
+    cblocks, qblocks = J.find_html_cblocks(qblocks)
+    cdblocks, qblocks = J.find_html_cdblocks(qblocks)
+    cpblocks, qblocks = J.find_html_cpblocks(qblocks)
+    steps[:cblocks] = (cblocks=cblocks, cdblocks=cdblocks, cpblocks=cpblocks,
+                         qblocks=qblocks)
+
+    hblocks = J.merge_blocks(qblocks, cblocks, cdblocks, cpblocks)
+    steps[:hblocks] = (hblocks=hblocks,)
+
+    return steps
 end


### PR DESCRIPTION
closes #205 and #206 with proper handling of 

* backslashes including the special `\\` which, as in LaTex, forces a  line return
* escaping of backtick doesn't error anymore
* usage of html entities now works

(also moderate clean up of some tests, introduction of `explore_md_steps` and `explore_h_steps` to cleanly explore what's being done in the respective parsing steps at test time)