### PR TITLE
support for commonmark style links

### DIFF
--- a/src/JuDoc.jl
+++ b/src/JuDoc.jl
@@ -84,6 +84,8 @@ include("converter/lx_simple.jl")
 include("converter/html_blocks.jl")
 include("converter/html_functions.jl")
 include("converter/html.jl")
+# > fighting Julia's markdown parser
+include("converter/fixer.jl")
 # > javascript
 include("converter/js_prerender.jl")
 

--- a/src/converter/fixer.jl
+++ b/src/converter/fixer.jl
@@ -1,0 +1,84 @@
+"""
+$(SIGNATURES)
+
+Direct inline-style links are properly processed by Julia's Markdown processor but not:
+
+* `[link title](https://www.google.com "Google's Homepage")`
+* `[link title][some reference]` and later `[some reference]: http://www.reddit.com`
+* `[link title]` and later `[link title]: https://www.mozilla.org`
+"""
+function find_and_fix_md_links(hs::String)::String
+    # 1. find all occurences of -- [...]: link
+    # NOTE at this point things have already been preprocessed so
+    # [ was changed for &#91; and ] for &#93; making the regex very readable
+
+    # here we're looking for [id]: link; 1=id 2=link
+    m_link_defs = collect(eachmatch(r"&#91;((?:(?!&#93;).)*?)&#93;:\s(\S+)", hs))
+
+    def_names = [def.captures[1] for def in m_link_defs]
+    def_links = [def.captures[2] for def in m_link_defs]
+
+    # here we're looking for [id] or [stuff][id] but not [id]:
+    m_link_refs = collect(eachmatch(r"&#91;(.*?)&#93;(?!:)(&#91;(.*?)&#93;)?", hs))
+
+    ref_names = [ifelse(ref.captures[3] === nothing || isempty(ref.captures[3]),
+                    ref.captures[1], ref.captures[3]) for ref in m_link_refs]
+    assoc_def = zeros(Int, length(m_link_refs)) # if 0 then nothing associated
+
+    all_matches = vcat(m_link_defs, m_link_refs)
+
+    # stop early if there's none of that stuff
+    isempty(all_matches) && return hs
+
+    sort!(all_matches, by = e -> e.offset)
+
+    # now for every ref, try to find an associated def; if none
+    # found then the relevant assoc_def will remain zero and that
+    # ref will be left in place as it was
+    for (i, refn) in enumerate(ref_names)
+        # check that there's a corresponding def, otherwise ignore
+        # we'll take the first match, it's up to the user not to have
+        # multiple definitions with the same id
+        j = findfirst(n->(n==refn), def_names)
+        j === nothing || (assoc_def[i] = j)
+    end
+
+    # reconstruct the text
+    h = IOBuffer()
+    head = 1
+    i = 0
+    for m in all_matches
+        # is it a def match or ref match?
+        if length(m.captures) == 3
+            i += 1
+            ref = m
+            # retrieve the index of the associated def
+            j = assoc_def[i]
+            iszero(j) && continue
+
+            # write what's before
+            offset = ref.offset
+            (head < offset) && write(h, subs(hs, head, prevind(hs, offset)))
+
+            # write the link
+            if ref.captures[3] !== nothing && isempty(ref.captures[3])
+                # [link text][] indicating that the link text is the title
+                write(h, "<a href=\"$(def_links[j])\" title=\"$(ref_names[i])\">$(ref_names[i])</a>")
+            else
+                # either [link text] and [link text]: ... elsewhere or
+                # [link text][id] and [id]: ... later
+                write(h, html_ahref(def_links[j], ref.captures[1]))
+            end
+            # move the head
+            head = nextind(hs, offset + length(ref.match) - 1)
+        else
+            def = m
+            # just move the head, don't write the def
+            head = nextind(hs, def.offset + length(def.match) - 1)
+        end
+    end
+    strlen = lastindex(hs)
+    (head < strlen) && write(h, subs(hs, head, strlen))
+
+    return String(take!(h))
+end

--- a/src/converter/fixer.jl
+++ b/src/converter/fixer.jl
@@ -10,26 +10,30 @@ Direct inline-style links are properly processed by Julia's Markdown processor b
 function find_and_fix_md_links(hs::String)::String
     # 1. find all occurences of -- [...]: link
     # NOTE at this point things have already been preprocessed so
-    # [ was changed for &#91; and ] for &#93; making the regex very readable
+    # [ was changed for &#91; and ] for &#93; and ! for &#33; making
+    # the regexes very readable...
 
     # here we're looking for [id]: link; 1=id 2=link
-    m_link_defs = collect(eachmatch(r"&#91;((?:(?!&#93;).)*?)&#93;:\s(\S+)", hs))
+    m_link_defs = collect(eachmatch(r"&#91;((?:(?!&#93;).)*?)&#93;:\s((?:(?!\<\/p\>)\S)+)", hs))
 
     def_names = [def.captures[1] for def in m_link_defs]
     def_links = [def.captures[2] for def in m_link_defs]
 
-    # here we're looking for [id] or [stuff][id] but not [id]:
-    m_link_refs = collect(eachmatch(r"&#91;(.*?)&#93;(?!:)(&#91;(.*?)&#93;)?", hs))
+    # here we're looking for [id] or [stuff][id] or ![stuff][id] but not [id]:
+    m_link_refs = collect(eachmatch(r"(&#33;)?&#91;(.*?)&#93;(?!:)(?:&#91;(.*?)&#93;)?", hs))
 
+    # recuperate the appropriate name which has a chance to match def_names
     ref_names = [ifelse(ref.captures[3] === nothing || isempty(ref.captures[3]),
-                    ref.captures[1], ref.captures[3]) for ref in m_link_refs]
-    assoc_def = zeros(Int, length(m_link_refs)) # if 0 then nothing associated
+                    ref.captures[2], ref.captures[3]) for ref in m_link_refs]
 
+    # allocate a vector of associated definitions for each ref; if 0 nothing matched
+    assoc_def = zeros(Int, length(m_link_refs))
+
+    # aggregate and sort all matches
     all_matches = vcat(m_link_defs, m_link_refs)
-
     # stop early if there's none of that stuff
     isempty(all_matches) && return hs
-
+    # sort by offset
     sort!(all_matches, by = e -> e.offset)
 
     # now for every ref, try to find an associated def; if none
@@ -48,34 +52,34 @@ function find_and_fix_md_links(hs::String)::String
     head = 1
     i = 0
     for m in all_matches
+        # write what's before
+        (head < m.offset) && write(h, subs(hs, head, prevind(hs, m.offset)))
         # is it a def match or ref match?
-        if length(m.captures) == 3
-            i += 1
+        if length(m.captures) == 3 # ref match
+            i  += 1
             ref = m
             # retrieve the index of the associated def
             j = assoc_def[i]
-            iszero(j) && continue
-
-            # write what's before
-            offset = ref.offset
-            (head < offset) && write(h, subs(hs, head, prevind(hs, offset)))
-
-            # write the link
-            if ref.captures[3] !== nothing && isempty(ref.captures[3])
-                # [link text][] indicating that the link text is the title
-                write(h, "<a href=\"$(def_links[j])\" title=\"$(ref_names[i])\">$(ref_names[i])</a>")
+            if iszero(j)
+                write(h, m.match)
             else
-                # either [link text] and [link text]: ... elsewhere or
-                # [link text][id] and [id]: ... later
-                write(h, html_ahref(def_links[j], ref.captures[1]))
+                # write the link
+                if ref.captures[3] !== nothing && isempty(ref.captures[3])
+                    # [link text][] indicating that the link text is the title
+                    write(h, html_ahref(def_links[j], ref_names[i]; title=ref_names[i]))
+                else
+                    if ref.captures[1] !== nothing # ![alt][id]
+                        write(h, html_img(def_links[j], ref.captures[2]))
+                    else
+                        # either [link text] and [link text]: ... elsewhere or
+                        # [link text][id] and [id]: ... later
+                        write(h, html_ahref(def_links[j], ref.captures[2]))
+                    end
+                end
             end
-            # move the head
-            head = nextind(hs, offset + length(ref.match) - 1)
-        else
-            def = m
-            # just move the head, don't write the def
-            head = nextind(hs, def.offset + length(def.match) - 1)
         end
+        # move the head after the match
+        head = nextind(hs, m.offset + length(m.match) - 1)
     end
     strlen = lastindex(hs)
     (head < strlen) && write(h, subs(hs, head, strlen))

--- a/src/converter/html.jl
+++ b/src/converter/html.jl
@@ -36,6 +36,12 @@ function convert_html(hs::AbstractString, allvars::PageVars; isoptim::Bool=false
     (head < strlen) && write(htmls, subs(hs, head, strlen))
 
     fhs = String(take!(htmls))
+
+    # See issue #204, basically not all markdown links are processed  as
+    # per common mark with the JuliaMarkdown, so this is a patch that kind
+    # of does
+    fhs = find_and_fix_md_links(fhs)
+
     # if it ends with </p>\n but doesn't start with <p>, chop it off
     # this may happen if the first element parsed is an ocblock (not text)
     δ = ifelse(endswith(fhs, "</p>\n") && !startswith(fhs, "<p>"), 5, 0)

--- a/src/converter/md_utils.jl
+++ b/src/converter/md_utils.jl
@@ -9,7 +9,7 @@ processor, this is relevant for things that are parsed within latex commands etc
 function md2html(ss::AbstractString; stripp::Bool=false, code::Bool=false)::AbstractString
     isempty(ss) && return ss
 
-    # Use the base Markdown -> Html converter and post process headers
+    # Use the base Markdown -> Html converter
     partial = ss |> fix_inserts |> Markdown.parse |> Markdown.html
 
     # In some cases, base converter adds <p>...</p>\n which we might not want

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -41,8 +41,8 @@ function write_page(root::String, file::String, head::String, pg_foot::String, f
 
     # adding document variables to the dictionary
     # note that some won't change and so it's not necessary to do this every time
-    # but it takes negligible time to do this so ¯\_(ツ)_/¯ (and it's less annoying than
-    # to keep tabs on which file has already been treated etc).
+    # but it takes negligible time to do this so ¯\_(ツ)_/¯ (and it's less annoying
+    # than keeping tabs on which file has already been treated etc).
     s = stat(fpath)
     set_var!(jd_vars, "jd_ctime", jd_date(unix2datetime(s.ctime)))
     set_var!(jd_vars, "jd_mtime", jd_date(unix2datetime(s.mtime)))

--- a/src/misc_html.jl
+++ b/src/misc_html.jl
@@ -3,7 +3,8 @@ $(SIGNATURES)
 
 Convenience function to introduce a hyper reference.
 """
-html_ahref(link::AbstractString, name::Union{Int,AbstractString}) = "<a href=\"$link\">$name</a>"
+html_ahref(link::AbstractString, name::Union{Int,AbstractString}; title::AbstractString="") =
+    "<a href=\"$link\"$(isempty(title) ? "" : "title=\"$(Markdown.htmlesc(title))\"")>$name</a>"
 
 """
 $(SIGNATURES)

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -165,7 +165,7 @@ end
 end
 
 
-@testset "links" begin
+@testset "fixlinks" begin
    st = raw"""
         A [link] and
         B [link 2] and
@@ -180,10 +180,50 @@ end
         """ * J.EOS
     @test isapproxstr(st |> seval, """
                         <p>
-                            A <a href="https://julialang.org/">link</a> and
-                            B <a href="https://www.mozilla.org/">link 2</a> and
-                            C <a href="https://www.python.org/" title="Python">Python</a> and
-                            D <a href="http://slashdot.org/">a link</a>
+                            A <a href=\"https://julialang.org/\">link</a> and
+                            B <a href=\"https://www.mozilla.org/\">link 2</a> and
+                            C <a href=\"https://www.python.org/\"title=\"Python\">Python</a> and
+                            D <a href=\"http://slashdot.org/\">a link</a> and
+                            blah
                             end
-                        </p>""")
+                         </p>""")
+end
+
+
+@testset "fixlinks2" begin
+    st = raw"""
+        A [link] and
+        B ![link][id] and
+        blah
+        [link]: https://julialang.org/
+        [id]: ./path/to/img.png
+        """ * J.EOS
+
+    @test isapproxstr(st |> seval, """
+                      <p>
+                          A <a href="https://julialang.org/">link</a> and
+                          B <img src="./path/to/img.png" alt="link"> and
+                          blah
+                      </p>""")
+end
+
+
+@testset "fixlinks3" begin
+    st = raw"""
+        A [link] and
+        B [unknown] and
+        C ![link][id] and
+        D
+        [link]: https://julialang.org/
+        [id]: ./path/to/img.png
+        [not]: https://www.mozilla.org/
+        """ * J.EOS
+
+    @test isapproxstr(st |> seval, """
+                      <p>
+                        A <a href="https://julialang.org/">link</a> and
+                        B &#91;unknown&#93; and
+                        C <img src="./path/to/img.png" alt="link"> and
+                        D
+                      </p>""")
 end

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -163,3 +163,27 @@ end
                     </ol>
                     """)
 end
+
+
+@testset "links" begin
+   st = raw"""
+        A [link] and
+        B [link 2] and
+        C [Python][] and
+        D [a link][1] and
+        blah
+        [link]: https://julialang.org/
+        [link 2]: https://www.mozilla.org/
+        [Python]: https://www.python.org/
+        [1]: http://slashdot.org/
+        end
+        """ * J.EOS
+    @test isapproxstr(st |> seval, """
+                        <p>
+                            A <a href="https://julialang.org/">link</a> and
+                            B <a href="https://www.mozilla.org/">link 2</a> and
+                            C <a href="https://www.python.org/" title="Python">Python</a> and
+                            D <a href="http://slashdot.org/">a link</a>
+                            end
+                        </p>""")
+end

--- a/test/global/postprocess.jl
+++ b/test/global/postprocess.jl
@@ -54,9 +54,9 @@ if J.JD_CAN_PRERENDER && J.JD_CAN_HIGHLIGHT
     """
   jskx = J.js_prerender_katex(hs)
   # conversion of `\(M\)` (inline)
-  @test occursin("""<span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>M</mi></mrow>""", jskx)
+  @test occursin("""<span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>M</mi></mrow>""", jskx)
   # conversion of the equation (display)
-  @test occursin("""<span class="katex-display"><span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>M</mi>""", jskx)
+  @test occursin("""<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>M</mi>""", jskx)
   jshl = J.js_prerender_highlight(hs)
   # conversion of the code
   @test occursin("""<pre><code class="julia hljs"><span class="hljs-keyword">using</span>""", jshl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,9 @@ begin
     isdir(p) && rm(p; recursive=true, force=true)
     # make dir, go in it, do the tests, then get completely out (otherwise windows
     # can't delete the folder)
-    mkdir(p); cd(p); include("global/postprocess.jl");  cd(joinpath(D, ".."))
+    mkdir(p); cd(p);
+    include("global/postprocess.jl");
+    cd(joinpath(D, ".."))
     # clean up
     rm(p; recursive=true, force=true)
 end


### PR DESCRIPTION
indirect links are now supported so stuff like

```
[link] ... 
[link]: url
```

or 

```
[link][] ...
[link]: url
```

or

```
[link][id]
[id]: url
```

all are roughly tested but I should probably get a night sleep on it before merging. Probably need to assess a few things:

* [x] does it work with images (I think it should but haven't tried)
* [x] does the Gruber's syntax for link names work in Julia? so like `[a link](url "link title")` if not, just document it and add support only if explicitly requested.