### PR TITLE
bunch of fixes to do with spacing and ordering and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1.2
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuDoc"
 uuid = "4ca9428c-4c75-11e9-2efb-bf5cb6c1e8f8"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/JuDoc.jl
+++ b/src/JuDoc.jl
@@ -12,7 +12,7 @@ import LiveServer
 
 using DocStringExtensions: SIGNATURES, TYPEDEF
 
-export serve, publish, cleanpull, newsite, optimize
+export serve, publish, cleanpull, newsite, optimize, jd2html
 
 # -----------------------------------------------------------------------------
 #
@@ -113,5 +113,19 @@ include("misc_html.jl")
 
 # ERROR TYPES
 include("error_types.jl")
+
+"""
+$SIGNATURES
+
+Return the HTML corresponding to a JuDoc-Markdown string.
+"""
+function jd2html(st::AbstractString)::String
+    def_GLOBAL_PAGE_VARS!()
+    def_GLOBAL_LXDEFS!()
+    CUR_PATH[] = "index.md"
+    m, v = convert_md(st * EOS, collect(values(GLOBAL_LXDEFS)))
+    h = convert_html(m, v)
+    return h
+end
 
 end # module

--- a/src/converter/fixer.jl
+++ b/src/converter/fixer.jl
@@ -56,7 +56,7 @@ function find_and_fix_md_links(hs::String)::String
             end
         end
         # move the head after the match
-        head = nextind(hs, m.offset + length(m.match) - 1)
+        head = nextind(hs, m.offset + lastindex(m.match) - 1)
     end
     strlen = lastindex(hs)
     (head < strlen) && write(h, subs(hs, head, strlen))

--- a/src/converter/html_blocks.jl
+++ b/src/converter/html_blocks.jl
@@ -32,7 +32,7 @@ end
 """
 $(SIGNATURES)
 
-Helper function to process an individual block when the block is a `HIsDef` such as `{{ ifdef
+Helper function to process an individual block when the block is a `HIsDef` such as `{{ isdef
 author }} {{ fill author }} {{ end }}`. Which checks if a variable exists and if it does, applies
 something.
 """

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -35,7 +35,6 @@ function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
     #> 1. Tokenize
     tokens  = find_tokens(mds, MD_TOKENS, MD_1C_TOKENS)
     fn_refs = validate_footnotes!(tokens)
-
     #> 1b. Find indented blocks
     tokens = find_indented_blocks(tokens, mds)
 
@@ -294,7 +293,10 @@ function convert_inter_html(ihtml::AS,
         prev = (m.offset - δ1 > 0) ? prevind(ihtml, m.offset - δ1) : 0
         (head ≤ prev) && write(htmls, subs(ihtml, head:prev))
         # move head appropriately
-        head = iend + δ2 + 1
+        head = iend + δ2
+        if head ≤ strlen
+            head += ifelse(ihtml[head] in (' ', '>'), 1, 0)
+        end
         # store the resolved block
         write(htmls, convert_block(blocks[i], lxcontext))
     end

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -289,8 +289,12 @@ function convert_inter_html(ihtml::AS,
         !(hasli2) && (c2b ≤ strlen - 4) && ihtml[c2a:c2b] == "</p>" && (δ2 = 4)
 
         # write whatever is at the front, skip the extra space if still present
-        δ1 = ifelse(iszero(δ1) && !hasli1, 1, δ1)
-        prev = (m.offset - δ1 > 0) ? prevind(ihtml, m.offset - δ1) : 0
+        prev = prevind(ihtml, m.offset - δ1)
+        if prev > 0
+            prev -= ifelse(ihtml[prev] == ' ', 1, 0)
+        else
+            prev = 0
+        end
         (head ≤ prev) && write(htmls, subs(ihtml, head:prev))
         # move head appropriately
         head = iend + δ2

--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -123,7 +123,9 @@ $(SIGNATURES)
 Helper function for the code block case of `convert_block`.
 """
 function convert_code_block(ss::SubString)::String
-    m = match(r"```([a-z-]*)(\:[a-zA-Z\\\/-_\.]+)?\s*\n?((?:.|\n)*)```", ss)
+    fencer = ifelse(startswith(ss, "`````"), "`````", "```")
+    reg    = Regex("$fencer([a-z-]*)(\\:[a-zA-Z\\\\\\/-_\\.]+)?\\s*\\n?((?:.|\\n)*)$fencer")
+    m      = match(reg, ss)
     lang  = m.captures[1]
     rpath = m.captures[2]
     code  = m.captures[3]

--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -187,7 +187,9 @@ function convert_indented_code_block(ss::SubString)::String
     # 1. decrease indentation of all lines (either frontal \n\t or \n⎵⎵⎵⎵)
     code = replace(ss, r"\n(?:\t| {4})" => "\n")
     # 2. return; lang is a LOCAL_PAGE_VARS that is julia by default and can be set
-    return html_code(strip(code), "{{fill lang}}")
+    sc = strip(code)
+    isempty(sc) && return ""
+    return html_code(sc, "{{fill lang}}")
 end
 
 """

--- a/src/parser/md_tokens.jl
+++ b/src/parser/md_tokens.jl
@@ -85,7 +85,9 @@ const MD_TOKENS = Dict{Char, Vector{TokenFinder}}(
     '`'  => [ isexactly("`", ('`',), false) => :CODE_SINGLE, # `⎵
               isexactly("``",('`',), false) => :CODE_DOUBLE, # ``⎵*
               isexactly("```", SPACER)      => :CODE_TRIPLE, # ```⎵*
-              incrlook(is_language)         => :CODE_LANG,   # ```lang*
+              isexactly("`````", SPACER)    => :CODE_PENTA,  # `````⎵*
+              is_language()                 => :CODE_LANG,   # ```lang*
+              is_language2()                => :CODE_LANG2,  # `````lang*
              ],
     ) # end dict
 #= NOTE
@@ -140,7 +142,9 @@ const MD_OCB = [
     # ---------------------------------------------------------------------
     OCProto(:COMMENT,         :COMMENT_OPEN, (:COMMENT_CLOSE,), false),
     OCProto(:CODE_BLOCK_LANG, :CODE_LANG,    (:CODE_TRIPLE,),   false),
+    OCProto(:CODE_BLOCK_LANG, :CODE_LANG2,   (:CODE_PENTA,),    false),
     OCProto(:CODE_BLOCK,      :CODE_TRIPLE,  (:CODE_TRIPLE,),   false),
+    OCProto(:CODE_BLOCK,      :CODE_PENTA,   (:CODE_PENTA,),    false),
     OCProto(:CODE_BLOCK_IND,  :LR_INDENT,    (:LINE_RETURN,),   false),
     OCProto(:CODE_INLINE,     :CODE_DOUBLE,  (:CODE_DOUBLE,),   false),
     OCProto(:CODE_INLINE,     :CODE_SINGLE,  (:CODE_SINGLE,),   false),

--- a/src/parser/md_tokens.jl
+++ b/src/parser/md_tokens.jl
@@ -40,7 +40,15 @@ const MD_TOKENS = Dict{Char, Vector{TokenFinder}}(
              ],
     ']'  => [ isexactly("]: ") => :LINK_DEF,
              ],
-    '\\' => [ isexactly("\\{")        => :INACTIVE,         # See note [^1]
+    '\\' => [ # -- special characters, see `find_special_chars` in ocblocks
+              isexactly("\\\\")       => :CHAR_LINEBREAK, # --> <br/>
+              isexactly("\\", (' ',)) => :CHAR_BACKSPACE, # --> &#92;
+              isexactly("\\*")        => :CHAR_ASTERISK,  # --> &#42;
+              isexactly("\\_")        => :CHAR_UNDERSCORE,# --> &#95;
+              isexactly("\\`")        => :CHAR_BACKTICK,  # --> &#96;
+              isexactly("\\@")        => :CHAR_ATSIGN,    # --> &#64;
+              # -- maths
+              isexactly("\\{")        => :INACTIVE,         # See note [^1]
               isexactly("\\}")        => :INACTIVE,         # See note [^1]
               isexactly("\\\$")       => :INACTIVE,         # See note [^1]
               isexactly("\\[")        => :MATH_C_OPEN,      # \[ ...
@@ -51,10 +59,8 @@ const MD_TOKENS = Dict{Char, Vector{TokenFinder}}(
               isexactly("\\end{equation}")   => :MATH_D_CLOSE,
               isexactly("\\begin{eqnarray}") => :MATH_EQA_OPEN,
               isexactly("\\end{eqnarray}")   => :MATH_EQA_CLOSE,
+              # -- latex
               isexactly("\\newcommand")      => :LX_NEWCOMMAND,
-              isexactly("\\\\")              => :CHAR_LINEBREAK, # will be replaced by <br/>
-              isexactly("\\", (' ',))        => :CHAR_BACKSPACE, # will be replaced by &#92;
-              isexactly("\\`")               => :CHAR_BACKTICK,  # will be replaced by &#96;
               incrlook((_, c) -> α(c))       => :LX_COMMAND,     # \command⎵*
              ],
     '@'  => [ isexactly("@def", (' ',)) => :MD_DEF_OPEN,  # @def var = ...

--- a/src/parser/md_tokens.jl
+++ b/src/parser/md_tokens.jl
@@ -217,3 +217,12 @@ MATH_BLOCKS_NAMES
 List of names of maths environments.
 """
 const MATH_BLOCKS_NAMES = [e.name for e ∈ MD_OCB_MATH]
+
+
+"""
+MD_OCB_NO_INNER
+
+List of names of blocks which will deactivate any block contained within them.
+See [`find_all_ocblocks`](@ref).
+"""
+const MD_OCB_NO_INNER = vcat(MD_OCB_ESC, MATH_BLOCKS_NAMES, :LXB)

--- a/src/parser/ocblocks.jl
+++ b/src/parser/ocblocks.jl
@@ -80,15 +80,16 @@ function find_all_ocblocks(tokens::Vector{Token}, ocplist::Vector{OCProto}; inma
         append!(ocbs_all, ocbs)
     end
     # it may happen that a block is contained in a larger escape block.
-    # For instance this can happen if there is a code block in an escape block (see e.g. #151).
-    # To fix this, we browse the escape blocks in backwards order and check if there is any other
-    # block within it.
+    # For instance this can happen if there is a code block in an escape block
+    # (see e.g. #151) or if there's indentation in a math block.
+    # To fix this, we browse the escape blocks in backwards order and check if
+    # there is any other block within it.
     i = length(ocbs_all)
     active = ones(Bool, i)
     all_heads = from.(ocbs_all)
     while i > 1
         cur_ocb = ocbs_all[i]
-        if active[i] && cur_ocb.name ∈ MD_OCB_ESC
+        if active[i] && cur_ocb.name ∈ MD_OCB_NO_INNER
             # find all blocks within the span of this block, deactivate all of them
             cur_head = all_heads[i]
             cur_tail = to(cur_ocb)

--- a/src/parser/ocblocks.jl
+++ b/src/parser/ocblocks.jl
@@ -222,6 +222,9 @@ function find_special_chars(tokens::Vector{Token})
     spch = Vector{HTML_SPCH}()
     isempty(tokens) && return spch
     for τ in tokens
+        τ.name == :CHAR_ASTERISK    && push!(spch, HTML_SPCH(τ.ss, "&#42;"))
+        τ.name == :CHAR_UNDERSCORE  && push!(spch, HTML_SPCH(τ.ss, "&#95;"))
+        τ.name == :CHAR_ATSIGN      && push!(spch, HTML_SPCH(τ.ss, "&#64;"))
         τ.name == :CHAR_BACKSPACE   && push!(spch, HTML_SPCH(τ.ss, "&#92;"))
         τ.name == :CHAR_BACKTICK    && push!(spch, HTML_SPCH(τ.ss, "&#96;"))
         τ.name == :CHAR_LINEBREAK   && push!(spch, HTML_SPCH(τ.ss, "<br/>"))

--- a/test/converter/eval.jl
+++ b/test/converter/eval.jl
@@ -23,8 +23,13 @@
     @test isfile(opath)
     @test read(opath, String) == "25"
 
-    @test occursin("code: <pre><code class=\"language-julia\">a = 5\nprint(a^2)</code></pre>", h)
-    @test occursin("then: <pre><code>25</code></pre> done.", h)
+    @test isapproxstr(h, raw"""
+            <p>Simple code:
+            <pre><code class="language-julia">a = 5
+            print(a^2)</code></pre>
+            then:
+            <pre><code>25</code></pre>
+            done.</p>""")
 end
 
 @testset "Eval (errs)" begin
@@ -39,7 +44,11 @@ end
         done.
         """ * J.EOS |> seval
 
-    @test occursin("code: <pre><code class=\"language-python\">a = 5\nprint(a**2)\n</code></pre> done.", h)
+    @test isapproxstr(h, raw"""
+            <p>Simple code:
+            <pre><code class="language-python">a = 5
+            print(a**2)</code></pre>
+            done.</p>""")
 end
 
 @testset "Eval (rinput)" begin
@@ -62,8 +71,13 @@ end
     @test isfile(opath)
     @test read(opath, String) == "25"
 
-    @test occursin("code: <pre><code class=\"language-julia\">a = 5\nprint(a^2)</code></pre>", h)
-    @test occursin("then: <pre><code>25</code></pre> done.", h)
+    @test isapproxstr(h, """
+            <p>Simple code:
+            <pre><code class="language-julia">a = 5
+            print(a^2)</code></pre>
+            then:
+            <pre><code>25</code></pre>
+            done.</p>""")
 
     # ------------
 
@@ -88,8 +102,12 @@ end
     @test isfile(opath)
     @test read(opath, String) == "25"
 
-    @test occursin("code: <pre><code class=\"language-julia\">a = 5\nprint(a^2)</code></pre>", h)
-    @test occursin("then: <pre><code>25</code></pre> done.", h)
+    @test isapproxstr(h, """
+            <p>Simple code:
+            <pre><code class="language-julia">a = 5
+            print(a^2)</code></pre>
+            then:
+            <pre><code>25</code></pre>  done.</p>""")
 end
 
 @testset "Eval (module)" begin

--- a/test/converter/markdown.jl
+++ b/test/converter/markdown.jl
@@ -62,10 +62,16 @@ end
     lxcontext = J.LxContext(lxcoms, lxdefs, braces)
 
     @test J.convert_block(blocks2insert[1], lxcontext) == "<div class=\"d\">.</div>"
-    @test J.convert_block(blocks2insert[2], lxcontext) == "\\[\\begin{array}{c} \\sin^2(x)+\\cos^2(x) &=& 1\\end{array}\\]"
+    @test isapproxstr(J.convert_block(blocks2insert[2], lxcontext), "\\[\\begin{array}{c} \\sin^2(x)+\\cos^2(x) &=& 1\\end{array}\\]")
 
     hstring = J.convert_inter_html(inter_html, blocks2insert, lxcontext)
-    @test hstring == "<p>ab<div class=\"d\">.</div> \\[\\begin{array}{c} \\sin^2(x)+\\cos^2(x) &=& 1\\end{array}\\]</p>\n"
+    @test isapproxstr(hstring, raw"""
+                        <p>
+                          ab<div class="d">.</div>
+                          \[\begin{array}{c}
+                            \sin^2(x)+\cos^2(x) &=& 1
+                          \end{array}\]
+                        </p>""")
 end
 
 
@@ -85,13 +91,21 @@ end
     inter_md, mblocks = steps[:inter_md]
     inter_html, = steps[:inter_html]
 
-    @test inter_md == "text A1 text A2  ##JDINSERT##  and\n ##JDINSERT## \n text C1  ##JDINSERT##  text C2\n then  ##JDINSERT## .\n"
+    @test isapproxstr(inter_md, """
+                                text A1 text A2  ##JDINSERT##  and
+                                ##JDINSERT##
+                                text C1  ##JDINSERT##  text C2
+                                then  ##JDINSERT## .""")
 
-    @test inter_html == "<p>text A1 text A2  ##JDINSERT##  and  ##JDINSERT##   text C1  ##JDINSERT##  text C2  then  ##JDINSERT## .</p>\n"
+    @test isapproxstr(inter_html, """<p>text A1 text A2  ##JDINSERT##  and  ##JDINSERT##   text C1  ##JDINSERT##  text C2  then  ##JDINSERT## .</p>""")
 
     lxcontext = J.LxContext(lxcoms, lxdefs, braces)
     hstring = J.convert_inter_html(inter_html, blocks2insert, lxcontext)
-    @test hstring == "<p>text A1 text A2 blah and \nescape B1\n  text C1 \\(\\mathrm{ b}\\) text C2  then part1: AA and part2: BB.</p>\n"
+    @test isapproxstr(hstring, """
+                                <p>text A1 text A2 blah and
+                                escape B1
+                                text C1 \\(\\mathrm{ b}\\) text C2
+                                then part1: AA and part2: BB.</p>""")
 end
 
 

--- a/test/global/cases1.jl
+++ b/test/global/cases1.jl
@@ -34,6 +34,8 @@ end
         \newcommand{\com}[1]{◲!#1◲}
         \com{A}
         """ * J.EOS
+    steps = st |> explore_md_steps
+    @test steps[:inter_md].inter_md == "\n ##JDINSERT## \n\n ##JDINSERT## \n"
     @test st |> conv == "⭒A⭒\n◲A◲"
 end
 
@@ -197,4 +199,4 @@ end
     J.def_GLOBAL_LXDEFS!()
     r = st |> conv
     @test occursin("here <a id=\"anchor\"></a> done.", r)
-end 
+end

--- a/test/global/ordering.jl
+++ b/test/global/ordering.jl
@@ -1,0 +1,125 @@
+# Following multiple issues over time with ordering, this attempts to have
+# bunch of test cases where it's clear in what order things are tokenized / found
+
+@testset "Ordering-1" begin
+    st = raw"""
+        A
+        <!--
+        C
+            indent
+        D -->
+        B
+        """ * J.EOS
+    steps = st |> explore_md_steps
+    blocks, = steps[:ocblocks]
+    @test length(blocks) == 1
+    @test blocks[1].name == :COMMENT
+    @test isapproxstr(st |> seval, """
+            <p>A</p>
+            <p>B</p>
+            """)
+end
+
+@testset "Ordering-2" begin
+    st = raw"""
+        A
+        \begin{eqnarray}
+            1 + 1 &=& 2
+        \end{eqnarray}
+        B
+        """ * J.EOS
+    steps = st |> explore_md_steps
+    blocks, = steps[:ocblocks]
+    @test length(blocks) == 1
+    @test blocks[1].name == :MATH_EQA
+
+    @test isapproxstr(st |> seval, raw"""
+            <p>A
+            \[\begin{array}{c}
+                1 + 1 &=& 2
+            \end{array}\]
+            B</p>""")
+end
+
+@testset "Ordering-3" begin
+    st = raw"""
+        A
+        \begin{eqnarray}
+            1 + 1 &=& 2
+        \end{eqnarray}
+        B
+        <!--
+            blah
+            \begin{eqnarray}
+                1 + 1 &=& 2
+            \end{eqnarray}
+        [blah](hello)
+        -->
+        C
+        """ * J.EOS
+    steps = st |> explore_md_steps
+    blocks, = steps[:ocblocks]
+    @test length(blocks) == 2
+    @test blocks[1].name == :COMMENT
+    @test blocks[2].name == :MATH_EQA
+
+    @test isapproxstr(st |> seval, raw"""
+            <p>A
+            \[\begin{array}{c}
+                1 + 1 &=& 2
+            \end{array}\]
+            B</p>
+            <p>C</p>""")
+end
+
+@testset "Ordering-4" begin
+    st = raw"""
+        \newcommand{\eqa}[1]{\begin{eqnarray}#1\end{eqnarray}}
+        A
+        \eqa{
+             B
+        }
+        C
+        """ * J.EOS
+    steps = st |> explore_md_steps
+    blocks, = steps[:ocblocks]
+
+    @test length(blocks) == 3
+    @test all(getproperty.(blocks, :name) .== :LXB)
+
+    @test isapproxstr(st |> seval, raw"""
+            <p>A
+            \[\begin{array}{c}
+                B
+            \end{array}\]
+            C</p>""")
+end
+
+@testset "Ordering-5" begin
+    st = raw"""
+        A [❗️_ongoing_ ] C
+        """ * J.EOS
+    @test isapproxstr(st |> seval, raw"""
+        <p>A &#91;❗️<em>ongoing</em> &#93; C</p>
+        """)
+    st = raw"""
+        0
+        * A
+            * B [❗️_ongoing_ ]<!--(ongoing)
+                ref:
+                >> url
+            -->
+        C
+        """ * J.EOS
+    @test isapproxstr(st |> seval, raw"""
+            <p>0</p>
+            <ul>
+              <li><p>A</p>
+                <ul>
+                  <li><p>B &#91;❗️<em>ongoing</em> &#93;</p></li>
+                </ul>
+              </li>
+            </ul>
+            <p>C</p>
+            """)
+end

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -10,3 +10,67 @@ end
     h = raw"""A **`master`** B.""" |> jd2html
     @test h == "<p>A <strong><code>master</code></strong> B.</p>\n"
 end
+
+@testset "Tickssss" begin # issue 219
+    st = raw"""A `B` C""" * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+    @test tokens[1].name == :CODE_SINGLE
+    @test tokens[2].name == :CODE_SINGLE
+
+    st = raw"""A ``B`` C""" * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+    @test tokens[1].name == :CODE_DOUBLE
+    @test tokens[2].name == :CODE_DOUBLE
+
+    st = raw"""A ``` B ``` C""" * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+    @test tokens[1].name == :CODE_TRIPLE
+    @test tokens[2].name == :CODE_TRIPLE
+
+    st = raw"""A ````` B ````` C""" * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+    @test tokens[1].name == :CODE_PENTA
+    @test tokens[2].name == :CODE_PENTA
+
+    st = raw"""A ```b B ``` C""" * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+    @test tokens[1].name == :CODE_LANG
+    @test tokens[2].name == :CODE_TRIPLE
+
+    st = raw"""A `````b B ````` C""" * J.EOS
+    tokens = J.find_tokens(st, J.MD_TOKENS, J.MD_1C_TOKENS)
+    @test tokens[1].name == :CODE_LANG2
+    @test tokens[2].name == :CODE_PENTA
+
+    h = raw"""
+        A
+        `````markdown
+        B
+        `````
+        C
+        """ |> jd2html
+
+    @test isapproxstr(h, raw"""
+            <p>A
+            <pre><code class="language-markdown">B
+            </code></pre> C</p>
+            """)
+
+    h = raw"""
+        A
+        `````markdown
+        ```julia
+        B
+        ```
+        `````
+        C
+        """ |> jd2html
+    @test isapproxstr(h, raw"""
+            <p>A
+            <pre><code class="language-markdown">```julia
+            B
+            ```
+            </code></pre> C</p>
+            """)
+
+end

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -1,0 +1,7 @@
+@testset "Bold x*" begin # issue 223
+    h = raw"**x\***" * J.EOS |> seval
+    @test h == "<p><strong>x&#42;</strong></p>\n"
+
+    h = raw"_x\__" * J.EOS |> seval
+    @test h == "<p><em>x&#95;</em></p>\n"
+end

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -5,3 +5,8 @@
     h = raw"_x\__" * J.EOS |> seval
     @test h == "<p><em>x&#95;</em></p>\n"
 end
+
+@testset "Bold code" begin # issue 222
+    h = raw"""A **`master`** B.""" |> jd2html
+    @test h == "<p>A <strong><code>master</code></strong> B.</p>\n"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ println("🍺")
 # PARSER folder
 println("PARSER/MD+LX")
 include("parser/markdown+latex.jl")
+include("parser/markdown-extra.jl")
 include("parser/footnotes.jl")
 println("🍺")
 println("PARSER/HTML")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,6 @@ include("converter/markdown2.jl")
 include("converter/markdown3.jl")
 include("converter/hyperref.jl")
 println("🍺")
-
 println("CONVERTER/HTML")
 include("converter/html.jl")
 println("🍺")
@@ -43,6 +42,7 @@ println("🍺")
 println("INTEGRATION")
 include("global/cases1.jl")
 include("global/cases2.jl")
+include("global/ordering.jl")
 
 begin
     # create temp dir to do complete integration testing (has to be here in order

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -78,6 +78,10 @@ function explore_md_steps(mds)
     inter_html = J.md2html(inter_md; stripp=false)
     steps[:inter_html] = (inter_html=inter_html,)
 
+    lxcontext = J.LxContext(lxcoms, lxdefs, braces)
+    hstring   = J.convert_inter_html(inter_html, mblocks, lxcontext)
+    steps[:hstring] = (hstring=hstring,)
+
     return steps
 end
 


### PR DESCRIPTION
- closes #234, closes #219, closes #222, closes #223, closes #145 
- blocks in maths envs are now disabled so that there's no bleeding of code in maths etc (#234) 
- adds tests to remove some spacing issues before or after insertions (e.g. if `\eqref{..}` is followed by a `.` , there shouldn't be a space between the insertion and the `.` something like `(9).`, this is more annoying than would appear due to the fact that the Julia Markdown parser removes whitespaces a bit arbitrarily). this also fixes #222 
- reinforced escaping to not have `\*` or `\_` confuse bold or emph environment (#223)
- penta ticks to fence triple ticks (#219) and reinforcement of the parser as a result allowing the use of a token validator when using a greedy rule to allow the discarding of a stack
- adds `jd2html` a function that allows somewone to directly test the conversion from a judoc-markdown string to html (should be doc'd)
+ patch release