### PR TITLE
Fix nested table of contents HTML

### DIFF
--- a/src/converter/html_functions.jl
+++ b/src/converter/html_functions.jl
@@ -102,33 +102,38 @@ The split is as follows:
 * h[4] indicates the level of the title
 """
 function hfun_toc()::String
-    inner  = ""
-    curlvl = 1
+    inner   = ""
+    baselvl = minimum(h[4] for h in values(PAGE_HEADERS)) - 1
+    curlvl  = baselvl
     for i ∈ 1:length(PAGE_HEADERS)
         h = PAGE_HEADERS[i]
         lvl = h[4]
-        if lvl < curlvl
-            # how many levels?
-            δ = curlvl - lvl
-            curlvl = lvl
-            for i = 1:δ
-                inner *= "</ol>"
+        if lvl ≤ curlvl
+            # Close previous list item
+            inner *= "</li>"
+
+            # Close additional sublists for each level eliminated
+            for i = curlvl-1:-1:lvl
+                inner *= "</ol></li>"
             end
+
+            # Reopen for this list item
+            inner *= "<li>"
         elseif lvl > curlvl
-            # how many levels?
-            δ = lvl - curlvl
-            curlvl = lvl
-            for i = 1:δ
-                inner *= "<ol>"
+            # Open additional sublists for each level added
+            for i = curlvl+1:lvl
+                inner *= "<ol><li>"
             end
         end
-        inner *= html_li(html_ahref_key(h[2], h[1]))
+        inner *= html_ahref_key(h[2], h[1])
+        curlvl = lvl
+        # At this point, number of sublists (<ol><li>) open equals curlvl
     end
-    # close at whatever level we are
-    for i = curlvl:-1:2
-        inner *= "</ol>"
+    # Close remaining lists, as if going down to the base level
+    for i = curlvl-1:-1:baselvl
+        inner *= "</li></ol>"
     end
-    toc = "<div class=\"jd-toc\"><ol>" * inner * "</ol></div>"
+    toc = "<div class=\"jd-toc\">" * inner * "</div>"
 end
 
 

--- a/src/misc_html.jl
+++ b/src/misc_html.jl
@@ -6,13 +6,6 @@ Convenience function to add an id attribute to a html element
 attr(name::Symbol, val::AS) = ifelse(isempty(val), "", " $name=\"$val\"")
 
 """
-$(SIGNATURES)
-
-Convenience function for a list item
-"""
-html_li(in::AS) = "<li>$(in)</li>"
-
-"""
 $SIGNATURES
 
 Convenience function for a sup item

--- a/test/converter/markdown2.jl
+++ b/test/converter/markdown2.jl
@@ -33,6 +33,7 @@ end
     h = raw"""
         \toc
         ## Hello `jd`
+        #### weirdly nested
         ### Goodbye!
         ## Done
         done.
@@ -40,16 +41,18 @@ end
     @test isapproxstr(h, raw"""
         <div class="jd-toc">
           <ol>
-            <ol>
-              <li><a href="/pub/ff/aa.html#hello_jd">Hello <code>jd</code></a></li>
+            <li>
+              <a href="/pub/ff/aa.html#hello_jd">Hello <code>jd</code></a>
               <ol>
+                <li><ol><li><a href="/pub/ff/aa.html#weirdly_nested">weirdly nested</a></li></ol></li>
                 <li><a href="/pub/ff/aa.html#goodbye">Goodbye&#33;</a></li>
               </ol>
-              <li><a href="/pub/ff/aa.html#done">Done</a></li>
-            </ol>
+            </li>
+            <li><a href="/pub/ff/aa.html#done">Done</a></li>
           </ol>
         </div>
         <h2 id="hello_jd"><a href="/pub/ff/aa.html#hello_jd">Hello <code>jd</code></a></h2>
+        <h4 id="weirdly_nested"><a href="/pub/ff/aa.html#weirdly_nested">weirdly nested</a></h4>
         <h3 id="goodbye"><a href="/pub/ff/aa.html#goodbye">Goodbye&#33;</a></h3>
         <h2 id="done"><a href="/pub/ff/aa.html#done">Done</a></h2>done.
         """)


### PR DESCRIPTION
HTML nested lists need to have the sublists [contained within the parent \<li\>](https://stackoverflow.com/questions/5899337/proper-way-to-make-html-nested-list). This PR changes the TOC generation to perform this nesting, as well as to detect the highest heading level (so as not to generate an empty H1 entry if the page contains no H1 headings).

Before this PR, note how the numbering is strange (because the \<ol\> tags are not contained within the list item, so essentially numbering is reset to 1 whenever an \<ol\> tag is seen, instead of nesting):

![Screenshot from 2019-09-28 16-48-18](https://user-images.githubusercontent.com/12903942/65822674-35b93980-e216-11e9-8605-10b613e44e46.png)

After this PR, the problem is fixed:

![Screenshot from 2019-09-28 17-20-36](https://user-images.githubusercontent.com/12903942/65822687-5e413380-e216-11e9-8e96-3ece25d0174e.png)
