### PR TITLE
Fix search for occur to account for _n headings

### DIFF
--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -107,7 +107,7 @@ function convert_header(β::OCBlock)::String
     # check if the header has appeared before
     rstitle  = refstring(title)
     level    = parse(Int, hk[2])
-    occur    = (hv[3] for hv ∈ values(PAGE_HEADERS) if hv[2] == rstitle)
+    occur    = (hv[3] for hv ∈ values(PAGE_HEADERS) if refstring(hv[1]) == rstitle)
     occur    = isempty(occur) ? 0 : maximum(occur)
     rstitle  = ifelse(occur==0, rstitle, "$(rstitle)_$(occur+1)")
     # save in list of headers

--- a/test/parser/markdown+latex.jl
+++ b/test/parser/markdown+latex.jl
@@ -254,6 +254,8 @@ end
         4
         ### t2
         5
+        ### t2
+        6
         """ * J.EOS |> seval
     @test isapproxstr(h, """
         <h1 id="t1"><a href="/index.html#t1">t1</a></h1>
@@ -266,6 +268,8 @@ end
         4
         <h3 id="t2_2"><a href="/index.html#t2_2">t2</a></h3>
         5
+        <h3 id="t2_3"><a href="/index.html#t2_3">t2</a></h3>
+        6
         """)
 end
 


### PR DESCRIPTION
Currently, only the first duplicated heading will have its ID renumbered, because the search for occur only looks for headings with the same ID. All of the duplicate headings after the first will be called `heading_2`:

```
### Heading (heading)
### Heading (heading_2)
### Heading (heading_2)
```

This changes the logic to look for all headings with the same refstring. There is probably still a problem if the user creates a document like

```
### Heading 2 (heading_2)
### Heading (heading)
### Heading (heading_2)
```

since the search won't find the explicit `heading_2` refstring. I'm not sure how to address this cleanly, however, so I opted for a more minimal change.

