### PR TITLE
Fix crash if non-ASCII character precedes $ math

### DIFF
--- a/src/converter/js_prerender.jl
+++ b/src/converter/js_prerender.jl
@@ -97,7 +97,7 @@ function js2html(hs::String, jsbuffer::IOBuffer, matches::Vector{RegexMatch},
     head, c = 1, 1
     for i ∈ 1:2:length(matches)-1
         mo, mc = matches[i:i+1]
-        write(htmls, subs(hs, head, mo.offset - 1))
+        write(htmls, subs(hs, head, prevind(hs, mo.offset)))
         pp = strip(parts[c])
         if startswith(pp, "<pre><code class=\"julia-repl")
             pp = replace(pp, r"shell&gt;"=>"<span class=hljs-metas>shell&gt;</span>")

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -290,10 +290,8 @@ function convert_inter_html(ihtml::AS,
 
         # write whatever is at the front, skip the extra space if still present
         prev = prevind(ihtml, m.offset - δ1)
-        if prev > 0
-            prev -= ifelse(ihtml[prev] == ' ', 1, 0)
-        else
-            prev = 0
+        if prev > 0 && ihtml[prev] == ' '
+            prev = prevind(ihtml, prev)
         end
         (head ≤ prev) && write(htmls, subs(ihtml, head:prev))
         # move head appropriately

--- a/test/global/postprocess.jl
+++ b/test/global/postprocess.jl
@@ -34,32 +34,46 @@
     @test occursin("=\"/prependme/libs/katex/katex.min.css", index)
 end
 
-if J.JD_CAN_PRERENDER && J.JD_CAN_HIGHLIGHT
-@testset "Prerender" begin
-  hs = raw"""
-    <!doctype html>
-    <html lang=en>
-    <meta charset=UTF-8>
-    <div class=jd-content>
-      <h1>Title</h1>
-      <p>Blah</p>
-      <p>Consider an invertible matrix \(M\) made of blocks \(A\), \(B\), \(C\) and \(D\) with</p>
-      \[ M \quad\!\! =\quad\!\! \begin{pmatrix} A & B \\ C & D \end{pmatrix} \]
-      <pre><code class=language-julia >using Test
-      # Woodbury formula
-      b = 2
-      println("hello $b")
-      </code></pre>
-    </div>
-    """
-  jskx = J.js_prerender_katex(hs)
-  # conversion of `\(M\)` (inline)
-  @test occursin("""<span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>M</mi></mrow>""", jskx)
-  # conversion of the equation (display)
-  @test occursin("""<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>M</mi>""", jskx)
-  jshl = J.js_prerender_highlight(hs)
-  # conversion of the code
-  @test occursin("""<pre><code class="julia hljs"><span class="hljs-keyword">using</span>""", jshl)
-  @test occursin(raw"""<span class="hljs-string">"hello <span class="hljs-variable">$b</span>"</span>""", jshl)
-end
-end # if can prerender
+if J.JD_CAN_PRERENDER; @testset "prerender" begin
+    @testset "katex" begin
+        hs = raw"""
+        <!doctype html>
+        <html lang=en>
+        <meta charset=UTF-8>
+        <div class=jd-content>
+        <p>range is \(10\sqrt{3}\)–\(20\sqrt{2}\) <!-- non-ascii en dash --></p>
+        <p>Consider an invertible matrix \(M\) made of blocks \(A\), \(B\), \(C\) and \(D\) with</p>
+        \[ M \quad\!\! =\quad\!\! \begin{pmatrix} A & B \\ C & D \end{pmatrix} \]
+        </div>
+        """
+
+        jskx = J.js_prerender_katex(hs)
+        # conversion of the non-ascii endash (inline)
+        @test occursin("""–<span class=\"katex\">""", jskx)
+        # conversion of `\(M\)` (inline)
+        @test occursin("""<span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>M</mi></mrow>""", jskx)
+        # conversion of the equation (display)
+        @test occursin("""<span class=\"katex-display\"><span class=\"katex\"><span class=\"katex-mathml\"><math xmlns=\"http://www.w3.org/1998/Math/MathML\"><semantics><mrow><mi>M</mi>""", jskx)
+    end
+
+    if J.JD_CAN_HIGHLIGHT; @testset "highlight" begin
+        hs = raw"""
+        <!doctype html>
+        <html lang=en>
+        <meta charset=UTF-8>
+        <div class=jd-content>
+        <h1>Title</h1>
+        <p>Blah</p>
+        <pre><code class=language-julia >using Test
+        # Woodbury formula
+        b = 2
+        println("hello $b")
+        </code></pre>
+        </div>
+        """
+        jshl = J.js_prerender_highlight(hs)
+        # conversion of the code
+        @test occursin("""<pre><code class="julia hljs"><span class="hljs-keyword">using</span>""", jshl)
+        @test occursin(raw"""<span class="hljs-string">"hello <span class="hljs-variable">$b</span>"</span>""", jshl)
+    end; end # if can highlight
+end; end # if can prerender

--- a/test/parser/markdown+latex.jl
+++ b/test/parser/markdown+latex.jl
@@ -49,6 +49,26 @@ end
 end
 
 
+@testset "Unicode lx" begin
+    st = raw"""
+    Call me “$x$”, not $🍕$.
+    """ * J.EOS
+
+    steps = explore_md_steps(st)
+    blocks, _ = steps[:ocblocks]
+
+    # first math block
+    β = blocks[1]
+    @test β.name == :MATH_A
+    @test β.ss == "\$x\$"
+
+    # second math block
+    β = blocks[2]
+    @test β.name == :MATH_A
+    @test β.ss == "\$🍕\$"
+end
+
+
 @testset "Lx defs+coms" begin
     st = raw"""
         \newcommand{\E}[1]{\mathbb E\left[#1\right]}blah de blah


### PR DESCRIPTION
Previously, if a sequence like `“$x$”` occurs (where the quotes are fancy quotes), then there would be a `StringIndexError`. This fixes the problem by calling `prevind` instead of subtracting `1`.

Since `prevind` with the default `n=1` can't return a negative number, I've also removed the else branch here since it's only setting 0 to 0.