### PR TITLE
Closes #250 (issue with reference links on first pass)

### DIFF
--- a/src/JuDoc.jl
+++ b/src/JuDoc.jl
@@ -104,7 +104,7 @@ include("converter/html_blocks.jl")
 include("converter/html_functions.jl")
 include("converter/html.jl")
 # > fighting Julia's markdown parser
-include("converter/fixer.jl")
+include("converter/link_fixer.jl")
 # > javascript
 include("converter/js_prerender.jl")
 

--- a/src/converter/html.jl
+++ b/src/converter/html.jl
@@ -68,7 +68,7 @@ function jd2html(st::AbstractString; internal::Bool=false, dir::String="")::Stri
         set_paths!()
         CUR_PATH[] = "index.md"
     end
-    m, v = convert_md(st * EOS, collect(values(GLOBAL_LXDEFS)); isrecursive=internal)
+    m, v = convert_md(st * EOS, collect(values(GLOBAL_LXDEFS)); isinternal=internal)
     h = convert_html(m, v)
     return h
 end

--- a/src/converter/html.jl
+++ b/src/converter/html.jl
@@ -43,7 +43,6 @@ function convert_html(hs::AS, allvars::PageVars; isoptim::Bool=false)::String
     if haskey(allvars, "reflinks") && allvars["reflinks"].first
         fhs = find_and_fix_md_links(fhs)
     end
-
     # if it ends with </p>\n but doesn't start with <p>, chop it off
     # this may happen if the first element parsed is an ocblock (not text)
     δ = ifelse(endswith(fhs, "</p>\n") && !startswith(fhs, "<p>"), 5, 0)
@@ -69,7 +68,7 @@ function jd2html(st::AbstractString; internal::Bool=false, dir::String="")::Stri
         set_paths!()
         CUR_PATH[] = "index.md"
     end
-    m, v = convert_md(st * EOS, collect(values(GLOBAL_LXDEFS)))
+    m, v = convert_md(st * EOS, collect(values(GLOBAL_LXDEFS)); isrecursive=internal)
     h = convert_html(m, v)
     return h
 end

--- a/src/converter/link_fixer.jl
+++ b/src/converter/link_fixer.jl
@@ -63,3 +63,16 @@ function find_and_fix_md_links(hs::String)::String
 
     return String(take!(h))
 end
+
+
+"""
+$(SIGNATURES)
+
+for a project website, for instance `username.github.io/project/` all paths should eventually
+be pre-prended with `/project/`. This would happen just before you publish the website.
+"""
+function fix_links(pg::String)::String
+    pp = strip(GLOBAL_PAGE_VARS["prepath"].first, '/')
+    ss = SubstitutionString("\\1=\"/$(pp)/")
+    return replace(pg, r"(src|href)\s*?=\s*?\"\/" => ss)
+end

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -12,13 +12,15 @@ well as a dictionary of page variables.
 **Keyword arguments**
 
 * `isrecursive=false`: a bool indicating whether the call is the parent call or a child call
+* `isinternal=false`:  a bool indicating whether the call stems from `jd2html` in internal mode
 * `isconfig=false`:    a bool indicating whether the file to convert is the configuration file
 * `has_mddefs=true`:   a bool indicating whether to look for definitions of page variables
 """
 function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
-                    isrecursive::Bool=false, isconfig::Bool=false, has_mddefs::Bool=true
+                    isrecursive::Bool=false, isinternal::Bool=false,
+                    isconfig::Bool=false, has_mddefs::Bool=true
                     )::Tuple{String,Union{Nothing,PageVars}}
-    if !isrecursive
+    if !(isrecursive || isinternal)
         def_LOCAL_PAGE_VARS!()  # page-specific variables
         def_PAGE_HEADERS!()     # all the headers
         def_PAGE_EQREFS!()      # page-specific equation dict (hrefs)

--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -26,12 +26,10 @@ page (inserting `head`, `pg_foot` and `foot`) and finally write it at the approp
 function write_page(root::String, file::String, head::String,
                     pg_foot::String, foot::String;
                     prerender::Bool=false, isoptim::Bool=false)::Nothing
-    # 0. create a dictionary with all the variables available to the page
     # 1. read the markdown into string, convert it and extract definitions
     # 2. eval the definitions and update the variable dictionary, also retrieve
     # document variables (time of creation, time of last modif) and add those
     # to the dictionary.
-    jd_vars = merge(GLOBAL_PAGE_VARS, copy(LOCAL_PAGE_VARS))
     fpath   = joinpath(root, file)
      # The curpath is the relative path starting after /src/ so for instance:
      # f1/blah/page1.md or index.md etc... this is useful in the code evaluation and management
@@ -160,16 +158,3 @@ Convenience function to assemble the html out of its parts.
 """
 build_page(head::String, content::String, pg_foot::String, foot::String)::String =
     "$head\n<div class=\"jd-content\">\n$content\n$pg_foot\n</div>\n$foot"
-
-
-"""
-$(SIGNATURES)
-
-for a project website, for instance `username.github.io/project/` all paths should eventually
-be pre-prended with `/project/`. This would happen just before you publish the website.
-"""
-function fix_links(pg::String)::String
-    pp = strip(GLOBAL_PAGE_VARS["prepath"].first, '/')
-    ss = SubstitutionString("\\1=\"/$(pp)/")
-    return replace(pg, r"(src|href)\s*?=\s*?\"\/" => ss)
-end


### PR DESCRIPTION
This closes #250. The issue was simple, the function `jd2html` which is the barebone converter from markdown to html is called in `add_rss_item` passing a keyword indicating that the call is internal.

However `jd2html` didn't pass that indication to `convert_md` which then assumed that this was a new page it was on and, as a result, flushed out dictionaries including the dictionary of reference links. As a result when trying to fix links, JuDoc saw an empty reference dictionary and assumed that these links were not links after all and so just outputted them as such. 