### PR TITLE
Fix sneaky issue with footnotes

### DIFF
--- a/src/converter/html.jl
+++ b/src/converter/html.jl
@@ -46,6 +46,8 @@ function jd2html(st::AbstractString; internal::Bool=false, dir::String="")::Stri
         FOLDER_PATH[] = isempty(dir) ? mktempdir() : dir
         set_paths!()
         CUR_PATH[] = "index.md"
+        def_GLOBAL_LXDEFS!()
+        def_GLOBAL_PAGE_VARS!()
     end
     m, v = convert_md(st * EOS, collect(values(GLOBAL_LXDEFS)); isinternal=internal)
     h = convert_html(m, v)

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -36,7 +36,8 @@ function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
 
     #> 1. Tokenize
     tokens  = find_tokens(mds, MD_TOKENS, MD_1C_TOKENS)
-    fn_refs = validate_footnotes!(tokens)
+    # distinguish fnref/fndef
+    validate_footnotes!(tokens)
     #> 1b. Find indented blocks
     tokens = find_indented_blocks(tokens, mds)
 
@@ -74,9 +75,12 @@ function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
     #
     # Forming of the html string
     #
+    # filter out the fnrefs that are left (still active)
+    # and add them to the blocks to insert
+    fnrefs = filter!(τ -> τ.name == :FOOTNOTE_REF, tokens)
 
     #> 1. Merge all the blocks that will need further processing before insertion
-    blocks2insert = merge_blocks(lxcoms, deactivate_divs(blocks), fn_refs, sp_chars)
+    blocks2insert = merge_blocks(lxcoms, deactivate_divs(blocks), sp_chars, fnrefs)
 
     #> 2. Form intermediate markdown + html
     inter_md, mblocks = form_inter_md(mds, blocks2insert, lxdefs)

--- a/src/parser/md_validate.jl
+++ b/src/parser/md_validate.jl
@@ -15,11 +15,8 @@ function validate_footnotes!(tokens::Vector{Token})
                 if !isnothing(m.captures[1])
                     # it's a def
                     tokens[i] = Token(:FOOTNOTE_DEF, τ.ss)
-                else
-                    # it's a ref, take and delete
-                    push!(fn_refs, τ)
-                    push!(rm, i)
                 end
+                # otherwise it's a ref, leave as is
             else
                 # delete
                 push!(rm, i)
@@ -27,7 +24,7 @@ function validate_footnotes!(tokens::Vector{Token})
         end
     end
     deleteat!(tokens, rm)
-    return fn_refs
+    return nothing
 end
 
 """

--- a/test/parser/footnotes.jl
+++ b/test/parser/footnotes.jl
@@ -34,3 +34,19 @@
                 </table>
             </p>""")
 end
+
+
+@testset "Fn in code" begin
+    s = raw"""
+        ```markdown
+       this has[^1]
+
+       [^1]: def
+       ```
+       blah
+       """
+    @test isapproxstr(s |> jd2html_td, """
+        <pre><code class="language-markdown">this has[^1]
+        [^1]: def
+        </code></pre> blah""")
+end

--- a/test/parser/footnotes.jl
+++ b/test/parser/footnotes.jl
@@ -7,6 +7,7 @@
            <p>A<sup id="fnref:1"><a href="/index.html#fndef:1" class="fnref">[1]</a></sup>
               B<sup id="fnref:blah"><a href="/index.html#fndef:blah" class="fnref">[2]</a></sup>
               C</p>""")
+
     st = """
         A[^1] B[^blah]
         C


### PR DESCRIPTION
Footnote ref tokens were deactivated properly in blocks that are meant to kill tokens within their span such as code blocks but were then used anyway further on in `merge_blocks`. This is now fixed.