### PR TITLE
Ignore indented blocks that are contained in other blocks (#285)

### DIFF
--- a/src/JuDoc.jl
+++ b/src/JuDoc.jl
@@ -75,7 +75,7 @@ const CUR_PATH = Ref("")
 const CUR_PATH_WITH_EVAL = Ref("")
 
 """Shorter name for a type that we use everywhere"""
-const AS = AbstractString
+const AS = Union{String,SubString{String}}
 
 """Convenience constants for an automatic message to add to code files."""
 const MESSAGE_FILE_GEN     = "This file was generated, do not modify it."

--- a/src/converter/lx.jl
+++ b/src/converter/lx.jl
@@ -30,14 +30,15 @@ function resolve_lxcom(lxc::LxCom, lxdefs::Vector{LxDef}; inmath::Bool=false)::S
         # lxdef = something -> maybe inmath + found; retrieve & apply
         partial = lxdef
         for (argnum, β) ∈ enumerate(lxc.braces)
+            content_ = ignore_starting_line_spaces(content(β))
             # space sensitive "unsafe" one
             # e.g. blah/!#1 --> blah/blah but note that
             # \command!#1 --> \commandblah and \commandblah would not be found
-            partial = replace(partial, "!#$argnum" => content(β))
+            partial = replace(partial, "!#$argnum" => content_)
             # non-space sensitive "safe" one
             # e.g. blah/#1 --> blah/ blah but note that
             # \command#1 --> \command blah and no error.
-            partial = replace(partial, "#$argnum" => " " * content(β))
+            partial = replace(partial, "#$argnum" => " " * content_)
         end
         partial = ifelse(inmath, mathenv(partial), partial) * EOS
     end

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -45,7 +45,9 @@ function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
     #>> a. find them
     blocks, tokens = find_all_ocblocks(tokens, MD_OCB_ALL)
     #>> b. merge CODE_BLOCK_IND which are separated by emptyness
-    merge_indented_code_blocks!(blocks, mds)
+    merge_indented_blocks!(blocks, mds)
+    #>> b'. only keep indented code blocks which are not contained in larger blocks (#285)
+    filter_indented_blocks!(blocks)
     #>> c. now that blocks have been found, line-returns can be dropped
     filter!(τ -> τ.name ∉ L_RETURNS, tokens)
     #>> d. filter out "fake headers" (opening ### that are not at the start of a line)

--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -24,7 +24,8 @@ function convert_block(β::AbstractBlock, lxcontext::LxContext)::AS
 
     # Div block --> need to process the block as a sub-element
     if βn == :DIV
-        ct, _ = convert_md(content(β) * EOS, lxcontext.lxdefs;
+        raw_ct = ignore_starting_line_spaces(content(β))
+        ct, _ = convert_md(raw_ct * EOS, lxcontext.lxdefs;
                            isrecursive=true, has_mddefs=false)
         name = chop(otok(β).ss, head=2, tail=0)
         return html_div(name, ct)

--- a/src/misc_utils.jl
+++ b/src/misc_utils.jl
@@ -81,7 +81,6 @@ julia> ss = SubString("hello", 2:4); JuDoc.to(ss)
 """
 to(ss::SubString)::Int = ss.offset + ss.ncodeunits
 
-
 """
 $(SIGNATURES)
 
@@ -94,6 +93,18 @@ julia> JuDoc.matchrange(match(r"ell", "hello"))
 ```
 """
 matchrange(m::RegexMatch)::UnitRange{Int} = m.offset .+ (0:(length(m.match)-1))
+
+
+"""
+$SIGNATURES
+
+In an lxdef or a div, ignore any whitespace at the beginning of lines to avoid ambiguities with indented
+code blocks.
+"""
+function ignore_starting_line_spaces(content::SubString)::AS
+    s = strip(content)
+    return replace(s, r"\n\s*" => "\n ")
+end
 
 # Other convenience functions
 

--- a/src/parser/lx_blocks.jl
+++ b/src/parser/lx_blocks.jl
@@ -65,6 +65,8 @@ function find_md_lxdefs(tokens::Vector{Token}, blocks::Vector{OCBlock})
         lxname = matched.captures[1]
         lxdef = content(defining_braces)
         todef = to(defining_braces)
+        # post-process the def
+        lxdef = post_process_lxdef(lxdef)
         # store the new latex command
         push!(lxdefs, LxDef(lxname, lxnarg, lxdef, fromτ, todef))
 
@@ -89,6 +91,18 @@ function find_md_lxdefs(tokens::Vector{Token}, blocks::Vector{OCBlock})
     blocks = blocks[@. ~braces_mask]
 
     return lxdefs, tokens, braces, blocks
+end
+
+
+"""
+$SIGNATURES
+
+In an lxdef, ignore any whitespace at the beginning of lines to avoid ambiguities with indented
+code blocks.
+"""
+function post_process_lxdef(lxdef::SubString)::AS
+    s = strip(lxdef)
+    return replace(s, r"\n\s*" => "\n ")
 end
 
 

--- a/src/parser/lx_blocks.jl
+++ b/src/parser/lx_blocks.jl
@@ -66,7 +66,7 @@ function find_md_lxdefs(tokens::Vector{Token}, blocks::Vector{OCBlock})
         lxdef = content(defining_braces)
         todef = to(defining_braces)
         # post-process the def
-        lxdef = post_process_lxdef(lxdef)
+        lxdef = ignore_starting_line_spaces(lxdef)
         # store the new latex command
         push!(lxdefs, LxDef(lxname, lxnarg, lxdef, fromτ, todef))
 
@@ -91,18 +91,6 @@ function find_md_lxdefs(tokens::Vector{Token}, blocks::Vector{OCBlock})
     blocks = blocks[@. ~braces_mask]
 
     return lxdefs, tokens, braces, blocks
-end
-
-
-"""
-$SIGNATURES
-
-In an lxdef, ignore any whitespace at the beginning of lines to avoid ambiguities with indented
-code blocks.
-"""
-function post_process_lxdef(lxdef::SubString)::AS
-    s = strip(lxdef)
-    return replace(s, r"\n\s*" => "\n ")
 end
 
 

--- a/src/parser/lx_tokens.jl
+++ b/src/parser/lx_tokens.jl
@@ -39,20 +39,20 @@ defined in the context of what we're currently parsing.
 mutable struct LxDef
     name::String
     narg::Int
-    def ::SubString
+    def ::AS
     # location of the definition > only things that can be mutated via pastdef!
     from::Int
     to  ::Int
 end
-LxDef(name::String, narg::Int, def::SubString) = LxDef(name, narg, def, 0, 0)
+LxDef(name::String, narg::Int, def::AS) = LxDef(name, narg, def, 0, 0)
 
 from(lxd::LxDef) = lxd.from
 to(lxd::LxDef)   = lxd.to
 
 
 """
-    pastdef(λ, a)
-    pastdef(vλ)
+pastdef(λ, a)
+pastdef(vλ)
 
 Convenience function to mark a definition as having been defined in the context i.e.: earlier than
 any other definition appearing in the current page.

--- a/src/parser/ocblocks.jl
+++ b/src/parser/ocblocks.jl
@@ -201,7 +201,7 @@ end
 """
 $SIGNATURES
 
-Helper function to [`merge_indented_code_blocks`](@ref).
+Helper function to [`merge_indented_blocks`](@ref).
 """
 function form_super_block!(blocks::Vector{OCBlock}, idx::Vector{Int},
                            curseq::Vector{Int}, del_blocks::Vector{Int})::Nothing
@@ -251,11 +251,11 @@ function filter_indented_blocks!(blocks::Vector{OCBlock})::Nothing
             end
         end
         if update
-            froms[.!active] = typemax(Int)
-            tos[.!active]   = 0
-            minfrom         = froms |> minimum
-            maxto           = tos |> maximum
-            update          = false
+            froms[.!active] .= typemax(Int)
+            tos[.!active]   .= 0
+            minfrom          = froms |> minimum
+            maxto            = tos |> maximum
+            update           = false
         end
     end
     deleteat!(blocks, idx[.!active])

--- a/src/parser/ocblocks.jl
+++ b/src/parser/ocblocks.jl
@@ -79,11 +79,17 @@ function find_all_ocblocks(tokens::Vector{Token}, ocplist::Vector{OCProto}; inma
         ocbs, tokens = find_ocblocks(tokens, ocp; inmath=inmath)
         append!(ocbs_all, ocbs)
     end
-    # it may happen that a block is contained in a larger escape block.
-    # For instance this can happen if there is a code block in an escape block
-    # (see e.g. #151) or if there's indentation in a math block.
-    # To fix this, we browse the escape blocks in backwards order and check if
-    # there is any other block within it.
+    # it may happen that a block is contained in a larger block
+    # there are two situations where we want to do something about it:
+    # Case 1 (solved here) where a block is inside a larger escape block
+    # Case 2 (solved in check_and_merge_indented_blocks!) when an indented
+    #   code block is contained inside a larger block
+    #
+    # CASE 1: block inside a larger escape block.
+    #   this can happen if there is a code block in an escape block
+    #   (see e.g. #151) or if there's indentation in a math block.
+    #   To fix this, we browse the escape blocks in backwards order and check if
+    #   there is any other block within it.
     i = length(ocbs_all)
     active = ones(Bool, i)
     all_heads = from.(ocbs_all)
@@ -165,7 +171,7 @@ $SIGNATURES
 When two indented code blocks follow each other and there's nothing in between (empty line(s)),
 merge them into a super block.
 """
-function merge_indented_code_blocks!(blocks::Vector{OCBlock}, mds::String)::Nothing
+function merge_indented_blocks!(blocks::Vector{OCBlock}, mds::String)::Nothing
     # indices of CODE_BLOCK_IND
     idx = [i for i in eachindex(blocks) if blocks[i].name == :CODE_BLOCK_IND]
     isempty(idx) && return
@@ -208,6 +214,52 @@ function form_super_block!(blocks::Vector{OCBlock}, idx::Vector{Int},
     append!(del_blocks, curseq[2:end])
     empty!(curseq)
     return
+end
+
+
+"""
+$SIGNATURES
+
+Discard any indented block that is within a larger block to avoid ambiguities (see #285).
+"""
+function filter_indented_blocks!(blocks::Vector{OCBlock})::Nothing
+    # retrieve the indices of the indented blocks
+    idx       = [i for i in eachindex(blocks) if blocks[i].name == :CODE_BLOCK_IND]
+    isempty(idx) && return nothing
+    # keep track of the ones that are active
+    active    = ones(Bool, length(idx))
+    # retrieve their span
+    indblocks = blocks[idx]
+    froms     = indblocks .|> from
+    tos       = indblocks .|> to
+    # retrieve the max/min span for faster processing
+    minfrom   = froms |> minimum
+    maxto     = tos |> maximum
+    update    = false
+    # go over all blocks and check if they contain an indented block
+    for block in blocks
+        # discard if the block is before or after all indented blocks
+        from_, to_ = from(block), to(block)
+        (to_ < minfrom || from_ > maxto) && continue
+        # otherwise check and deactivate if it's contained
+        for k in eachindex(active)
+            active[k] || continue
+            indblock = blocks[idx[k]]
+            if from_ < from(indblock) && to_ > to(indblock)
+                active[k] = false
+                update = true
+            end
+        end
+        if update
+            froms[.!active] = typemax(Int)
+            tos[.!active]   = 0
+            minfrom         = froms |> minimum
+            maxto           = tos |> maximum
+            update          = false
+        end
+    end
+    deleteat!(blocks, idx[.!active])
+    return nothing
 end
 
 

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -73,5 +73,15 @@ end
             ```
             </code></pre> C</p>
             """)
+end
 
+@testset "Nested ind" begin # issue 285
+    h = raw"""
+    \newcommand{\hello}{
+        yaya
+        bar bar
+    }
+    \hello
+    """ |> jd2html_td
+    @test isapproxstr(h, raw"""yaya  bar bar""")
 end

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -84,4 +84,22 @@ end
     \hello
     """ |> jd2html_td
     @test isapproxstr(h, raw"""yaya  bar bar""")
+    h = raw"""
+    @@da
+        @@db
+            @@dc
+                blah
+            @@
+        @@
+    @@
+    """ |> jd2html_td
+    @test isapproxstr(h, raw"""
+            <div class="da">
+                <div class="db">
+                    <div class="dc">
+                        blah
+                    </div>
+                </div>
+            </div>
+            """)
 end

--- a/test/parser/markdown-extra.jl
+++ b/test/parser/markdown-extra.jl
@@ -102,4 +102,11 @@ end
                 </div>
             </div>
             """)
+    h = raw"""
+    \newcommand{\hello}[1]{#1}
+    \hello{
+        good lord
+    }
+    """ |> jd2html_td
+    @test isapproxstr(h, "good lord")
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -63,7 +63,8 @@ function explore_md_steps(mds)
 
     # ocblocks
     blocks, tokens = J.find_all_ocblocks(tokens, J.MD_OCB_ALL)
-    J.merge_indented_code_blocks!(blocks, mds)
+    J.merge_indented_blocks!(blocks, mds)
+    J.filter_indented_blocks!(blocks)
     steps[:ocblocks] = (blocks=blocks, tokens=tokens)
 
     # filter


### PR DESCRIPTION
* ignores indented blocks that are contained inside other stuff (closes #285)

Now this can be done safely:

```julia
\newcommand{\hello}[1]{hello #1} 
\hello{
    good lord
}
```

whereas before it would have inserted some code stuff.