### PR TITLE
EOS whitespace handling

### DIFF
--- a/src/converter/html.jl
+++ b/src/converter/html.jl
@@ -4,6 +4,7 @@ $(SIGNATURES)
 Convert a judoc html string into a html string (i.e. replace `{{ ... }}` blocks).
 """
 function convert_html(hs::AS, allvars::PageVars; isoptim::Bool=false)::String
+    isempty(hs) && return hs
     # Tokenize
     tokens = find_tokens(hs, HTML_TOKENS, HTML_1C_TOKENS)
 
@@ -42,6 +43,7 @@ $SIGNATURES
 Return the HTML corresponding to a JuDoc-Markdown string.
 """
 function jd2html(st::AbstractString; internal::Bool=false, dir::String="")::String
+    isempty(st) && return st
     if !internal
         FOLDER_PATH[] = isempty(dir) ? mktempdir() : dir
         set_paths!()

--- a/src/converter/lx.jl
+++ b/src/converter/lx.jl
@@ -42,7 +42,6 @@ function resolve_lxcom(lxc::LxCom, lxdefs::Vector{LxDef}; inmath::Bool=false)::S
         end
         partial = ifelse(inmath, mathenv(partial), partial) * EOS
     end
-
     # reprocess (we don't care about jd_vars=nothing)
     plug, _ = convert_md(partial, lxdefs, isrecursive=true, isconfig=false, has_mddefs=false)
     return plug

--- a/src/converter/md.jl
+++ b/src/converter/md.jl
@@ -38,6 +38,8 @@ function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
     tokens  = find_tokens(mds, MD_TOKENS, MD_1C_TOKENS)
     # distinguish fnref/fndef
     validate_footnotes!(tokens)
+    # ignore header tokens that are not at the start of a line
+    validate_headers!(tokens)
     #> 1b. Find indented blocks
     tokens = find_indented_blocks(tokens, mds)
 
@@ -50,8 +52,6 @@ function convert_md(mds::String, pre_lxdefs::Vector{LxDef}=Vector{LxDef}();
     filter_indented_blocks!(blocks)
     #>> c. now that blocks have been found, line-returns can be dropped
     filter!(τ -> τ.name ∉ L_RETURNS, tokens)
-    #>> d. filter out "fake headers" (opening ### that are not at the start of a line)
-    filter!(β -> validate_header_block(β), blocks)
     #>> e. keep track of literal content of possible link definitions to use
     validate_and_store_link_defs!(blocks)
 

--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -9,14 +9,14 @@ function convert_block(β::AbstractBlock, lxcontext::LxContext)::AS
     β isa HTML_SPCH     && return ifelse(isempty(β.r), β.ss, β.r)
     # Return relevant interpolated string based on case
     βn = β.name
-    βn ∈ MD_HEADER         && return convert_header(β)
+    βn ∈ MD_HEADER         && return convert_header(β, lxcontext.lxdefs)
     βn == :CODE_INLINE     && return html_code_inline(content(β) |> htmlesc)
     βn == :CODE_BLOCK_LANG && return convert_code_block(β.ss)
     βn == :CODE_BLOCK_IND  && return convert_indented_code_block(β.ss)
     βn == :CODE_BLOCK      && return html_code(strip(content(β)), "{{fill lang}}")
     βn == :ESCAPE          && return chop(β.ss, head=3, tail=3)
     βn == :FOOTNOTE_REF    && return convert_footnote_ref(β)
-    βn == :FOOTNOTE_DEF    && return convert_footnote_def(β, lxcontext)
+    βn == :FOOTNOTE_DEF    && return convert_footnote_def(β, lxcontext.lxdefs)
     βn == :LINK_DEF        && return ""
 
     # Math block --> needs to call further processing to resolve possible latex
@@ -102,9 +102,10 @@ $(SIGNATURES)
 
 Helper function for the case of a header block (H1, ..., H6).
 """
-function convert_header(β::OCBlock)::String
+function convert_header(β::OCBlock, lxdefs::Vector{LxDef})::String
     hk       = lowercase(string(β.name)) # h1, h2, ...
-    title, _ = convert_md(content(β) * EOS; isrecursive=true, has_mddefs=false)
+    title, _ = convert_md(content(β) * EOS, lxdefs;
+                          isrecursive=true, has_mddefs=false)
     rstitle  = refstring(title)
     # check if the header has appeared before and if so suggest
     # an altered refstring; if that altered refstring also exist
@@ -330,7 +331,7 @@ $(SIGNATURES)
 
 Helper function to convert a `[^1]: ...` into a html table for the def.
 """
-function convert_footnote_def(β::OCBlock, lxcontext::LxContext)::String
+function convert_footnote_def(β::OCBlock, lxdefs::Vector{LxDef})::String
     # otok(β) is [^id]:
     id = match(r"\[\^(.*?)\]:", otok(β).ss).captures[1]
     pos = 0
@@ -345,7 +346,7 @@ function convert_footnote_def(β::OCBlock, lxcontext::LxContext)::String
         return ""
     end
     # need to process the content which could contain stuff
-    ct, _ = convert_md(content(β) * EOS, lxcontext.lxdefs;
+    ct, _ = convert_md(content(β) * EOS, lxdefs;
                        isrecursive=true, has_mddefs=false)
     """
     <table class="fndef" id="fndef:$id">

--- a/src/parser/lx_blocks.jl
+++ b/src/parser/lx_blocks.jl
@@ -136,7 +136,6 @@ function find_md_lxcoms(tokens::Vector{Token}, lxdefs::Vector{LxDef},
     for (i, τ) ∈ enumerate(tokens)
         active_τ[i] || continue
         (τ.name == :LX_COMMAND) || continue
-
         # 1. look for the definition given the command name
         lxname   = τ.ss
         lxdefref = retrieve_lxdefref(lxname, lxdefs, inmath, offset)

--- a/src/parser/md_tokens.jl
+++ b/src/parser/md_tokens.jl
@@ -7,8 +7,7 @@ cannot appear again in a larger token.
 const MD_1C_TOKENS = LittleDict{Char, Symbol}(
     '{'  => :LXB_OPEN,
     '}'  => :LXB_CLOSE,
-    '\n' => :LINE_RETURN,
-    EOS  => :EOS,
+    '\n' => :LINE_RETURN
     )
 
 
@@ -125,7 +124,7 @@ L_RETURNS
 Convenience tuple containing the name for standard line returns and line returns followed by an
 indentation (either a quadruple space or a tab).
 """
-const L_RETURNS = (:LINE_RETURN, :LR_INDENT)
+const L_RETURNS = (:LINE_RETURN, :LR_INDENT, :EOS)
 
 
 """
@@ -150,19 +149,19 @@ const MD_OCB = [
     OCProto(:CODE_INLINE,     :CODE_DOUBLE,  (:CODE_DOUBLE,),   false),
     OCProto(:CODE_INLINE,     :CODE_SINGLE,  (:CODE_SINGLE,),   false),
     OCProto(:ESCAPE,          :ESCAPE,       (:ESCAPE,),        false),
-    OCProto(:FOOTNOTE_DEF,    :FOOTNOTE_DEF, (L_RETURNS..., :EOS), false),
-    OCProto(:LINK_DEF,        :LINK_DEF,     (L_RETURNS..., :EOS), false),
+    OCProto(:FOOTNOTE_DEF,    :FOOTNOTE_DEF, L_RETURNS,         false),
+    OCProto(:LINK_DEF,        :LINK_DEF,     L_RETURNS,         false),
     # ------------------------------------------------------------------
-    OCProto(:H1,              :H1_OPEN,      (L_RETURNS..., :EOS), false), # see [^3]
-    OCProto(:H2,              :H2_OPEN,      (L_RETURNS..., :EOS), false),
-    OCProto(:H3,              :H3_OPEN,      (L_RETURNS..., :EOS), false),
-    OCProto(:H4,              :H4_OPEN,      (L_RETURNS..., :EOS), false),
-    OCProto(:H5,              :H5_OPEN,      (L_RETURNS..., :EOS), false),
-    OCProto(:H6,              :H6_OPEN,      (L_RETURNS..., :EOS), false),
+    OCProto(:H1,              :H1_OPEN,      L_RETURNS,     false), # see [^3]
+    OCProto(:H2,              :H2_OPEN,      L_RETURNS,     false),
+    OCProto(:H3,              :H3_OPEN,      L_RETURNS,     false),
+    OCProto(:H4,              :H4_OPEN,      L_RETURNS,     false),
+    OCProto(:H5,              :H5_OPEN,      L_RETURNS,     false),
+    OCProto(:H6,              :H6_OPEN,      L_RETURNS,     false),
     # ------------------------------------------------------------------
-    OCProto(:MD_DEF,          :MD_DEF_OPEN,  (L_RETURNS..., :EOS), false), # see [^4]
-    OCProto(:LXB,             :LXB_OPEN,     (:LXB_CLOSE,),        true ),
-    OCProto(:DIV,             :DIV_OPEN,     (:DIV_CLOSE,),        true ),
+    OCProto(:MD_DEF,          :MD_DEF_OPEN,  L_RETURNS,     false), # see [^4]
+    OCProto(:LXB,             :LXB_OPEN,     (:LXB_CLOSE,), true ),
+    OCProto(:DIV,             :DIV_OPEN,     (:DIV_CLOSE,), true ),
     ]
 #= NOTE:
 * [3] a header can be closed by either a line return or an end of string (for instance in the case

--- a/src/parser/md_tokens.jl
+++ b/src/parser/md_tokens.jl
@@ -179,6 +179,13 @@ All header symbols.
 """
 const MD_HEADER = (:H1, :H2, :H3, :H4, :H5, :H6)
 
+"""
+MD_HEADER_OPEN
+
+All header symbols (opening).
+"""
+const MD_HEADER_OPEN = (:H1_OPEN, :H2_OPEN, :H3_OPEN, :H4_OPEN, :H5_OPEN, :H6_OPEN)
+
 
 """
 MD_OCB_ESC

--- a/src/parser/tokens.jl
+++ b/src/parser/tokens.jl
@@ -28,6 +28,7 @@ struct Token <: AbstractBlock
     ss::SubString
 end
 
+to(β::Token) = ifelse(β.name == :EOS, from(β), to(β.ss))
 
 """
 $(TYPEDEF)
@@ -350,5 +351,6 @@ function find_tokens(str::AS,
         # dictionaries have been checked etc, moving on to the next valid char
         head_idx = nextind(str, head_idx)
     end
+    push!(tokens, Token(:EOS, subs(str, EOS_idx, EOS_idx)))
     return tokens
 end

--- a/test/parser/markdown+latex.jl
+++ b/test/parser/markdown+latex.jl
@@ -316,3 +316,31 @@ end
         """ |> seval
     @test isapproxstr(h, """<p>Hello <br/> goodbye</p>""")
 end
+
+@testset "Header+lx" begin
+    h = "# blah" |> jd2html_td
+    @test h == raw"""<h1 id="blah"><a href="/index.html#blah">blah</a></h1>"""
+    h = raw"""
+        \newcommand{\foo}{foo}
+        \newcommand{\header}{# hello}
+        \foo
+        \header
+        """ |> jd2html_td
+    @test h == raw"""foo <h1 id="hello"><a href="/index.html#hello">hello</a></h1>"""
+    h = raw"""
+        \newcommand{\foo}{foo}
+        \foo hello
+        """ |> jd2html_td
+    @test h == raw"""foo hello"""
+    h = raw"""
+        \newcommand{\foo}{blah}
+        # \foo hello
+        """ |> jd2html_td
+    @test h == raw"""<h1 id="blah_hello"><a href="/index.html#blah_hello">blah hello</a></h1>"""
+    h = raw"""
+        \newcommand{\foo}{foo}
+        \newcommand{\header}[2]{!#1 \foo #2}
+        \header{##}{hello}
+        """ |> jd2html_td
+    @test h == raw"""<h2 id="foo_hello"><a href="/index.html#foo_hello">foo  hello</a></h2>"""
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -57,6 +57,7 @@ function explore_md_steps(mds)
     # tokenize
     tokens  = J.find_tokens(mds, J.MD_TOKENS, J.MD_1C_TOKENS)
     fn_refs = J.validate_footnotes!(tokens)
+    J.validate_headers!(tokens)
     tokens  = J.find_indented_blocks(tokens, mds)
     steps[:tokenization] =  (tokens=tokens,)
     steps[:fn_validation] = (fn_refs=fn_refs,)
@@ -69,7 +70,6 @@ function explore_md_steps(mds)
 
     # filter
     filter!(τ -> τ.name ∉ J.L_RETURNS, tokens)
-    filter!(β -> J.validate_header_block(β), blocks)
     steps[:filter] = (tokens=tokens, blocks=blocks)
 
     J.validate_and_store_link_defs!(blocks)


### PR DESCRIPTION
Before, one couldn't easily define a command that would itself define headers (the OCBlock wouldn't close properly).

Now this is possible:

```
\newcommand{\backtotop}{<a href="#pagetop">&#94;</a>}
\newcommand{\header}[2]{!#1 \backtotop #2}
\header{##}{hello}
```