### PR TITLE
Edit build.jl to use global Node installation if the user sets ENV["NODE"]

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -20,7 +20,13 @@ const PIP = begin
         end
     end
 end
-const NODE = NodeJS.nodejs_cmd()
+const NODE = begin
+    if "NODE" ∈ keys(ENV)
+        ENV["NODE"]
+    else
+        NodeJS.nodejs_cmd()
+    end
+end
 
 #=
 Pre-rendering


### PR DESCRIPTION
Follows the suggestion of Issue #294 