### PR TITLE
small fix to parse all caps lang

### DIFF
--- a/src/converter/md_blocks.jl
+++ b/src/converter/md_blocks.jl
@@ -205,7 +205,7 @@ Helper function for the code block case of `convert_block`.
 """
 function convert_code_block(ss::SubString)::String
     fencer = ifelse(startswith(ss, "`````"), "`````", "```")
-    reg    = Regex("$fencer([a-z-]*)(\\:[a-zA-Z\\\\\\/-_\\.]+)?\\s*\\n?((?:.|\\n)*)$fencer")
+    reg    = Regex("$fencer([a-zA-Z]+)(\\:[a-zA-Z\\\\\\/-_\\.]+)?\\s*\\n?((?:.|\\n)*)$fencer")
     m      = match(reg, ss)
     lang   = m.captures[1]
     rpath  = m.captures[2]

--- a/test/converter/markdown3.jl
+++ b/test/converter/markdown3.jl
@@ -330,3 +330,17 @@ end
         and later </p>
         """)
 end
+
+@testset "TOML lang" begin
+    s = raw"""
+       blah
+       ```TOML
+       socrates
+       ```
+       end
+       """
+    @test isapproxstr(s |> jd2html_td, """
+        <p>blah
+        <pre><code class=\"language-TOML\">socrates</code></pre>
+    end</p>""")
+end


### PR DESCRIPTION
Fixes an issue where programming languages in all caps would not be recognised  (bc of an improperly written  regex... 🙄 ) thanks to  @cormullion for the heads  up  https://github.com/cormullion/julialangblog/issues/5 