### PR TITLE
emergency patch due to  1.3 release markdown parser silliness

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuDoc"
 uuid = "4ca9428c-4c75-11e9-2efb-bf5cb6c1e8f8"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/converter/lx_simple.jl
+++ b/test/converter/lx_simple.jl
@@ -65,7 +65,7 @@ end
 
     # NOTE: in VERSION > 1.4, Markdown has alignment for tables:
     # -- https://github.com/JuliaLang/julia/pull/33849
-    if VERSION > v"1.3.0-rc5.1"
+    if VERSION > v"1.3.0"
         shouldbe = """
             <p>A table:
             <table>
@@ -93,7 +93,7 @@ end
         \tableinput{A,B,C}{/assets/testcsv.csv}
         Done.
         """ |> seval
-    if VERSION > v"1.3.0-rc5.1"
+    if VERSION > v"1.3.0"
         shouldbe = """
             <p>A table:
             <table>
@@ -139,7 +139,7 @@ end
         \tableinput{}{/assets/testcsv.csv}
         Done.
         """ |> seval
-    if VERSION > v"1.3.0-rc5.1"
+    if VERSION > v"1.3.0"
         shouldbe = """
             <p>A table:
             <table>
@@ -166,7 +166,7 @@ end
         Done.
         """ |> seval
 
-    if VERSION > v"1.3.0-rc5.1"
+    if VERSION > v"1.3.0"
         shouldbe = """
             <p>A table: <table><tr><th align="right">A</th><th align="right">B</th><th align="right">C</th></tr><tr><td align="right">string1</td><td align="right">1.567</td><td align="right">0</td></tr><tr><td align="right"></td><td align="right"></td><td align="right"></td></tr><tr><td align="right">l i n e</td><td align="right">.158</td><td align="right">99999999</td></tr></table>
             Done.</p>"""

--- a/test/global/cases1.jl
+++ b/test/global/cases1.jl
@@ -172,7 +172,7 @@ end
         | C | D |
         """ * J.EOS
 
-    if VERSION > v"1.3.0-rc5.1"
+    if VERSION > v"1.3.0"
         @test isapproxstr(st |> conv,
             """<table><tr><th align="center">A</th><th align="center">B</th></tr><tr><td align="center">C</td><td align="center">D</td></tr></table>""")
     else

--- a/test/global/cases2.jl
+++ b/test/global/cases2.jl
@@ -76,7 +76,7 @@ end
         C
         """ * J.EOS
 
-    if VERSION > v"1.3.0-rc5.1"
+    if VERSION > v"1.3.0"
         @test isapproxstr(st |> seval, raw"""<p>A</p>
 <h3 id="title"><a href="/pub/pg1.html#title">Title</a></h3>
 <table><tr><th align="center">No.</th><th align="center">Graph</th><th align="center">Vertices</th><th align="center">Edges</th></tr><tr><td align="center">1</td><td align="center">Twitter Social Circles</td><td align="center">81,306</td><td align="center">1,342,310</td></tr><tr><td align="center">2</td><td align="center">Astro-Physics Collaboration</td><td align="center">17,903</td><td align="center">197,031</td></tr><tr><td align="center">3</td><td align="center">Facebook Social Circles</td><td align="center">4,039</td><td align="center">88,234</td></tr></table>


### PR DESCRIPTION
Apparently they rolled back the  table alignment thing for 1.3 and put  it in 1.4 🙄 