### PR TITLE
Feature request : callback after built page

### DIFF
--- a/src/manager/file_utils.jl
+++ b/src/manager/file_utils.jl
@@ -20,6 +20,14 @@ end
 """
 $(SIGNATURES)
 
+Executed after each page is rendered. Can be overwritten.
+"""
+function on_page_built(jd_vars) end
+
+
+"""
+$(SIGNATURES)
+
 Take a path to an input markdown file (via `root` and `file`), then construct the appropriate HTML
 page (inserting `head`, `pg_foot` and `foot`) and finally write it at the appropriate place.
 """
@@ -80,6 +88,7 @@ function write_page(root::String, file::String, head::String,
 
     # 5. write the html file where appropriate
     write(joinpath(out_path(root), change_ext(file)), pg)
+    on_page_built(jd_vars)
     return nothing
 end
 


### PR DESCRIPTION
this allows to define a function that will be executed each time a page is built

in my case, I wanted to save all the jd_vars in an external file for later use, so I will overload the function  `on_page_built` with : 
```julia
function JuDoc.on_page_built(jd_vars)
    d = Dict()
    for (key, value) in pairs(jd_vars)
        d[key] = value |> first
    end

    output = joinpath("assets/vars", JuDoc.change_ext(basename(d["jd_rpath"]), ".json"))
    open(output, "w") do f
        write(f, JSON.json(d, 2))
    end
end
```

I'm not sure if it's the right way to do it, but this way it doesn't change the current behaviour or built time when this function is unchanged, but allows for more complex behaviours