### PR TITLE
Fix for #326, avoid double escaping when pre-rendering a html code  block

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JuDoc"
 uuid = "4ca9428c-4c75-11e9-2efb-bf5cb6c1e8f8"
 authors = ["Thibaut Lienart <tlienart@me.com>"]
-version = "0.4"
+version = "0.4.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/test/global/html_esc.jl
+++ b/test/global/html_esc.jl
@@ -1,0 +1,8 @@
+# See https://github.com/tlienart/JuDoc.jl/issues/326
+
+@testset "Issue 326" begin
+    h1 = "<div class=\"hello\">Blah</div>"
+    h1e = Markdown.htmlesc(h1)
+    @test J.is_html_escaped(h1e)
+    @test J.html_unescape(h1e) == h1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,7 @@ println("GLOBAL")
 include("global/cases1.jl")
 include("global/cases2.jl")
 include("global/ordering.jl")
+include("global/html_esc.jl")
 
 begin
     # create temp dir to do complete integration testing (has to be here in order


### PR DESCRIPTION
closes #326 