### PR TITLE
Fix sitemap test: derive base URL from website_url

### DIFF
--- a/test/global/sitemap.jl
+++ b/test/global/sitemap.jl
@@ -6,11 +6,15 @@
     @test occursin(raw"""
         <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""", fc)
+    # the base url comes from the template's `website_url`; read it from the
+    # generated config rather than hardcoding a host, so the test doesn't break
+    # when FranklinTemplates changes it (see #1116 CI).
+    cfg = read(joinpath(p, "basic", "config.md"), String)
+    website_url = match(r"website_url\s*=\s*\"(.*?)\"", cfg).captures[1]
     # check pages
     for pg in ("", "menu1", "menu2", "menu3")
         pgg = joinpath(pg, "index.html")
-        @test occursin("""
-            <loc>https://juliadocs.org/FranklinTemplates.jl/$pgg</loc>""", fc)
+        @test occursin("<loc>$(joinpath(website_url, pgg))</loc>", fc)
     end
 end
 
@@ -19,6 +23,7 @@ end
     @test isfile(f)
     fc = prod(readlines(f, keep=true))
 
-    @test occursin(raw"""
-        Sitemap: https://juliadocs.org/FranklinTemplates.jl/sitemap.xml""", fc)
+    cfg = read(joinpath(p, "basic", "config.md"), String)
+    website_url = match(r"website_url\s*=\s*\"(.*?)\"", cfg).captures[1]
+    @test occursin("Sitemap: $(joinpath(website_url, "sitemap.xml"))", fc)
 end


### PR DESCRIPTION
## Problem

CI on `master` is red on **every** job (including stable Julia). The `Sitemap gen` / `Robots.txt gen` tests hardcode `https://juliadocs.org/FranklinTemplates.jl/...`:

```
Expression: occursin("<loc>https://juliadocs.org/FranklinTemplates.jl/index.html</loc>", fc)
Evaluated:  occursin("<loc>https://juliadocs.org/FranklinTemplates.jl/index.html</loc>",
                     "...<loc>https://tlienart.github.io/FranklinTemplates.jl/index.html</loc>...")
```

But those URLs are generated from the template's `website_url` page variable, which the latest **released** FranklinTemplates (v0.10.3) still sets to `https://tlienart.github.io/FranklinTemplates.jl/` (in `common/config.md`). The expectation was changed to `juliadocs.org` in 014c6ce ("Update a bunch of links"), but the dependency that actually produces the URL hasn't shipped that change — so the test fails.

## Fix

Read `website_url` from the generated config and build the expected URLs with the same `joinpath` the sitemap/robots generators use (`src/manager/sitemap_generator.jl`, `src/manager/robots_generator.jl`). The test now verifies the sitemap reflects the template's configured base URL, without hardcoding a host — so it passes whether FranklinTemplates ships `tlienart.github.io` or `juliadocs.org`.

## Verification

Full test suite passes locally on Julia 1.12 (`Sitemap gen | 6 6`, `Robots.txt gen | 2 2`).

Note: nightly will still be red until #1117 (Julia 1.14 Markdown compatibility) lands — that's a separate, unrelated failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)